### PR TITLE
Update Assignment-3.cpp

### DIFF
--- a/Assignment-3/Assignment-3.cpp
+++ b/Assignment-3/Assignment-3.cpp
@@ -83,7 +83,7 @@ void AbstractExecution::handleCycleWTO(const ICFGCycleWTO* cycle) {
 	if (!is_feasible) {
 		return;
 	} else {
-		AbstractState pre_as = preAbsTrace[cycle->head()->node()];
+		AEState pre_as = preAbsTrace[cycle->head()->node()];
 		// set -widen-delay
 		s32_t widen_delay = Options::WidenDelay();
 		bool increasing = true;


### PR DESCRIPTION
We must narrow pre_as with postAbsTraceTrace which is AEState with no conversion to AbstractState. The question cannot be solved without this change.