### PR TITLE
Sync to upstream SVF: LLVM 21.1.0, drop deadsnakes PPA

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
       "type": "shell",
       // We assume that SVF is installed under the same folder as Software-Security-Analysis 
       // You need to change LLVM_DIR, SVF_DIR and Z3_DIR to the correct paths if you installed SVF in a different location.
-      "command": "cmake -DCMAKE_BUILD_TYPE=Debug -DSVF_DIR=../SVF -DLLVM_DIR=../SVF/llvm-16.0.0.obj -DZ3_DIR=../SVF/z3.obj . && make",
+      "command": "cmake -DCMAKE_BUILD_TYPE=Debug -DSVF_DIR=../SVF -DLLVM_DIR=../SVF/llvm-21.1.0.obj -DZ3_DIR=../SVF/z3.obj . && make",
       "options": {
         "cwd": "${workspaceFolder}"
       },

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,13 @@ ENV build_deps="wget xz-utils git gdb tcl software-properties-common"
 RUN apt-get update --fix-missing
 RUN apt-get install -y $build_deps $lib_deps
 
-# Add deadsnakes PPA for multiple Python versions 
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
-RUN set -ex; \
-    apt-get update && apt-get install -y python3.10-dev python3-pip \
-            && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1;
-RUN python3 -m pip install pysvf -i https://test.pypi.org/simple/
-RUN python3 -m pip install z3-solver
+# Use the python3 that ships with the Ubuntu 24.04 base image (python 3.12).
+# Avoid pulling python3.10 from ppa:deadsnakes/ppa — Launchpad's PPA infrastructure
+# has been intermittently unreachable from CI runners (HTTP 504 / 2-minute timeouts
+# from add-apt-repository), and SVF does not pin a Python version.
+RUN apt-get install -y python3-dev python3-pip
+RUN python3 -m pip install --break-system-packages pysvf -i https://test.pypi.org/simple/
+RUN python3 -m pip install --break-system-packages z3-solver
 
 # Fetch and build SVF source.
 RUN echo "Downloading LLVM and building SVF to " ${HOME}


### PR DESCRIPTION
Match the upstream SVF/build.sh pin (MajorLLVMVer=21) and remove the ppa:deadsnakes/ppa python3.10 install path. Launchpad's PPA infrastructure has been intermittently unreachable from CI runners (HTTP 504 from add-apt-repository), and SVF does not pin a Python version, so the Ubuntu base-image python3 (24.04 = 3.12) is sufficient.