### PR TITLE
Drop ppa:ubuntu-toolchain-r/test — Launchpad flake on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
           sudo apt-get install cmake gcc g++ nodejs doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev
 
       # install llvm and svf


### PR DESCRIPTION
The 'sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test' step has been intermittently failing with HTTP 504 from Launchpad (lazr.restfulclient.errors.ServerError: Gateway Time-out).  ubuntu-24.04 ships gcc-13 by default, so the toolchain-test PPA is unnecessary — just drop the add-apt-repository step (and the redundant 'apt-get update' that follows it).

Same change pattern that was already applied to SVF-Python's release.yml and SVF-example's workflow.