### PR TITLE
Install `ipykernel` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get install -y $build_deps $lib_deps
 # Avoid pulling python3.10 from ppa:deadsnakes/ppa — Launchpad's PPA infrastructure
 # has been intermittently unreachable from CI runners (HTTP 504 / 2-minute timeouts
 # from add-apt-repository), and SVF does not pin a Python version.
-RUN apt-get install -y python3-dev python3-pip
+RUN apt-get install -y python3-dev python3-pip python3-ipykernel
 RUN python3 -m pip install --break-system-packages pysvf -i https://test.pypi.org/simple/
 RUN python3 -m pip install --break-system-packages z3-solver
 


### PR DESCRIPTION
The labs use Jupyter Notebook, but Jupyter isn't installed by default on the Docker image, leading to errors in VS Code when run out-of-the-box:

```
Running cells with 'Python 3.12.3' requires the ipykernel package.
[Create a Python Environment](command:jupyter.createPythonEnvAndSelectController) with the required packages.
Or install 'ipykernel' using the command: '/bin/python3 -m pip install ipykernel -U --user --force-reinstall'
```

The package `python3-ipykernel` is now installed through the Dockerfile with this PR.