### PR TITLE
Update `pysvf` pip install to be on PyPI over TestPyPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get install -y $build_deps $lib_deps
 # has been intermittently unreachable from CI runners (HTTP 504 / 2-minute timeouts
 # from add-apt-repository), and SVF does not pin a Python version.
 RUN apt-get install -y python3-dev python3-pip python3-ipykernel
-RUN python3 -m pip install --break-system-packages pysvf -i https://test.pypi.org/simple/
+RUN python3 -m pip install --break-system-packages pysvf
 RUN python3 -m pip install --break-system-packages z3-solver
 
 # Fetch and build SVF source.


### PR DESCRIPTION
From https://github.com/SVF-tools/SVF-Python/commit/4477140901c103ade79d6bc665f2771e57354691, `pysvf` is now no longer in TestPyPI. This commit fixes the Dockerfile to install the correct `pysvf`.