### PR TITLE
Add VS Code extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "ms-toolsai.jupyter"
+    ]
+}


### PR DESCRIPTION
In our build instructions on the wiki, we recommend that students install the Python and Jupyter extensions. This PR adds an `extension.json`, which allows VS Code to recommend these extensions on launch.