### PR TITLE
Fix Docker debug path and ptrace metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN echo "Building SVF ..."
 RUN bash ./build.sh debug
 
 # Export SVF, llvm, z3 paths
-ENV PATH=${HOME}/SVF/Release-build/bin:$PATH
+ENV PATH=${HOME}/SVF/Debug-build/bin:$PATH
 ENV PATH=${HOME}/SVF/llvm-$llvm_version.obj/bin:$PATH
 ENV SVF_DIR=${HOME}/SVF
 ENV LLVM_DIR=${HOME}/SVF/llvm-$llvm_version.obj
@@ -53,3 +53,6 @@ RUN echo "Building Software-Security-Analysis ..."
 RUN sed -i 's/lldb/gdb/g' ${HOME}/Software-Security-Analysis/.vscode/launch.json
 RUN cmake -DCMAKE_BUILD_TYPE=Debug .
 RUN make -j8
+
+# GDB inside Docker requires ptrace permissions at container runtime.
+LABEL devcontainer.metadata='[{"runArgs":["--cap-add=SYS_PTRACE","--security-opt=seccomp=unconfined"]}]'


### PR DESCRIPTION
## Summary
- align the SVF PATH with the existing `build.sh debug` build output by using `Debug-build` instead of `Release-build`
- add devcontainer metadata so VS Code Dev Containers created from this image request `SYS_PTRACE` and an unconfined seccomp profile for GDB

## Notes
- this intentionally keeps the existing Dockerfile build commands and `.vscode/launch.json` behavior unchanged
- plain `docker run` still needs equivalent runtime flags: `--cap-add=SYS_PTRACE --security-opt seccomp=unconfined`
