### PR TITLE
Build Docker image in Release mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,10 @@ WORKDIR ${HOME}
 RUN git clone "https://github.com/SVF-tools/SVF.git"
 WORKDIR ${HOME}/SVF
 RUN echo "Building SVF ..."
-RUN bash ./build.sh debug
+RUN bash ./build.sh
 
 # Export SVF, llvm, z3 paths
-ENV PATH=${HOME}/SVF/Debug-build/bin:$PATH
+ENV PATH=${HOME}/SVF/Release-build/bin:$PATH
 ENV PATH=${HOME}/SVF/llvm-$llvm_version.obj/bin:$PATH
 ENV SVF_DIR=${HOME}/SVF
 ENV LLVM_DIR=${HOME}/SVF/llvm-$llvm_version.obj
@@ -51,7 +51,7 @@ RUN git clone "https://github.com/SVF-tools/Software-Security-Analysis.git"
 WORKDIR ${HOME}/Software-Security-Analysis
 RUN echo "Building Software-Security-Analysis ..."
 RUN sed -i 's/lldb/gdb/g' ${HOME}/Software-Security-Analysis/.vscode/launch.json
-RUN cmake -DCMAKE_BUILD_TYPE=Debug .
+RUN cmake -DCMAKE_BUILD_TYPE=Release .
 RUN make -j8
 
 # GDB inside Docker requires ptrace permissions at container runtime.


### PR DESCRIPTION
## Summary
- build SVF with its default Release configuration instead of `debug`
- point the SVF tool PATH back to `Release-build/bin`
- configure Software-Security-Analysis with `CMAKE_BUILD_TYPE=Release` in the Docker image

## Notes
- current C++ exercise failure paths already pair disabled assertions with explicit `abort()` calls in the relevant places
- not locally rebuilt or retested, per request
