### PR TITLE
Align functionality of Z3 in Python and C++

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "ms-python.python",
-        "ms-toolsai.jupyter"
+        "ms-toolsai.jupyter",
+        "ms-vscode.cpptools-extension-pack",
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,17 +20,17 @@
       "MIMode": "lldb"  // change to "gdb" if you are using non-macOS system
     },
     {
-        "name": "(debug) Launch Python",
-        "type": "python",
-        "request": "launch",
+      "name": "(debug) Launch Python",
+      "type": "debugpy",
+      "request": "launch",
       // Please change to the executable of your current assignment. Python version of the lab exercises are using Jupyter Notebook.
       // |  Assignment-1    | "${workspaceFolder}/Assignment-1/Python/test.py"      | "-icfg", "Assignment-1/Tests/testcases/icfg/test1.ll" |
       // |  Assignment-2    | "${workspaceFolder}/Assignment-2/Python/test-sse.py"      | "Assignment-2/Tests/testcases/sse/test1.ll" |
       // |  Assignment-3    | "${workspaceFolder}/Assignment-3/Python/test-ae.py"      | "Assignment-3/Tests/stmt.ll"  (or buf_overflow.ll / null_deref.ll) |
-        "program": "${workspaceFolder}/HelloWorld/hello.py",  
-        "args": [],
-        "cwd": "${workspaceFolder}",
-        "console": "integratedTerminal"
+      "program": "${workspaceFolder}/HelloWorld/hello.py",  
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "C_Cpp.intelliSenseEngine": "Default"
+  "C_Cpp.intelliSenseEngine": "default"
 }

--- a/Assignment-2/Python/Z3SSEMgr.py
+++ b/Assignment-2/Python/Z3SSEMgr.py
@@ -194,18 +194,26 @@ class Z3Mgr:
             idx = nIter[0]
             node = nIter[1]
             e = self.getEvalExpr(self.getZ3Expr(idx, callingCtx))
+
             if z3.is_int_value(e) == False:
                 continue
+
             if isinstance(node, pysvf.ValVar):
+                expr_name = "ValVar" + str(idx) + "(" + node.getName() +")"
+                
                 if self.isVirtualMemAddress(e.as_long()):
                     valstr = "\t Value: " + hex(e.as_long()) + "\n"
                 else:
                     valstr = "\t Value: " + str(e.as_long()) + "\n"
-                print_val_map["ValVar" + str(idx) + "("+ node.getName() +")" ] = valstr
-                val_key_map[idx] = "ValVar" + str(idx) + "("+ node.getName() +")"
+                
+                print_val_map[expr_name] = valstr
+                val_key_map[idx] = expr_name
             else:
+                expr_name = "ObjVar" + str(idx) + " (" + hex(self.getVirtualMemAddress(idx)) + ") "
+
                 if self.isVirtualMemAddress(e.as_long()):
                     stored_value = self.getEvalExpr(self.loadValue(e))
+
                     if z3.is_int_value(stored_value):
                         if self.isVirtualMemAddress(stored_value.as_long()):
                             valstr = "\t Value: " + hex(stored_value.as_long()) + "\n"
@@ -215,17 +223,18 @@ class Z3Mgr:
                         valstr = "\t Value: NULL" + "\n"
                 else:
                     valstr = "\t Value: NULL" + "\n"
-                print_val_map["ObjVar" + str(idx) + " (0x" + hex(idx) + ") "] = valstr
-                obj_key_map[idx] = "ObjVar" + str(idx) + " (0x" + hex(idx) + ") "
+
+                print_val_map[expr_name] = valstr
+                obj_key_map[idx] = expr_name
+                
         print("\n-----------SVFVar and Value-----------")
         for idx, key in obj_key_map.items():
             val = print_val_map[key].strip()
-            label = f"ObjVar{idx} (0x{idx:x})"
+            label = key
             print(f"{label:<30} {val}")
 
         for idx, key in val_key_map.items():
             val = print_val_map[key].strip()
-            #label = f"ValVar{idx}"
             label = key
             print(f"{label:<30} {val}")
         print("-----------------------------------------")

--- a/Assignment-2/Python/Z3SSEMgr.py
+++ b/Assignment-2/Python/Z3SSEMgr.py
@@ -134,10 +134,10 @@ class Z3Mgr:
         assert isinstance(idx, int), "idx is not a valid integer, the type of idx is {}".format(type(idx))
         return self.addressMask + idx
 
-    def getMemobjAddress(self, addr: int) -> z3.ExprRef:
+    def getMemObjAddress(self, addr: int) -> z3.ExprRef:
         assert isinstance(addr, int), "addr is not a valid integer, the type of addr is {}".format(type(addr))
         obj_idx = self.getInternalId(addr)
-        assert(self.pag.getGNode(obj_idx).isObjVar()), "Invalid memory object index"
+        assert(self.pag.getGNode(obj_idx).isObjVar()), "Fail to get the MemObj!"
         return self.createExprForObjVar(self.pag.getGNode(obj_idx).asObjVar())
 
     def z3ExprToNumValue(self, expr: z3.ExprRef) -> int:
@@ -149,7 +149,7 @@ class Z3Mgr:
             assert False, "this expression is not numeral"
             sys.exit(1)
 
-    def getGepobjAddress(self, base_expr: z3.ExprRef, offset: int) -> z3.ExprRef:
+    def getGepObjAddress(self, base_expr: z3.ExprRef, offset: int) -> z3.ExprRef:
         assert isinstance(base_expr, z3.ExprRef), "base_expr is not a valid z3 expression, the type of base_expr is {}".format(type(base_expr))
         assert isinstance(offset, int), "offset is not a valid integer, the type of offset is {}".format(type(offset))
 
@@ -206,9 +206,7 @@ class Z3Mgr:
             else:
                 if self.isVirtualMemAddress(e.as_long()):
                     stored_value = self.getEvalExpr(self.loadValue(e))
-                    if z3.is_int_value(stored_value) == False:
-                        continue
-                    if isinstance(stored_value, z3.ExprRef):
+                    if z3.is_int_value(stored_value):
                         if self.isVirtualMemAddress(stored_value.as_long()):
                             valstr = "\t Value: " + hex(stored_value.as_long()) + "\n"
                         else:


### PR DESCRIPTION
The output of `printExprValues` in the Python version is slightly different to the one in the C++ version. Previously, the Python version would output something like this:

```
-----------SVFVar and Value-----------
ObjVar2 (0x2)                  Value: NULL
ObjVar3 (0x3)                  Value: NULL
ObjVar5 (0x5)                  Value: NULL
ObjVar9 (0x9)                  Value: NULL
ObjVar12 (0xc)                 Value: NULL
ObjVar15 (0xf)                 Value: NULL
ValVar0()                      Value: 2
ValVar1()                      Value: 2
ValVar4(main)                  Value: 0x7f000005
ValVar7(cmp)                   Value: 1
ValVar8()                      Value: 3
ValVar11(svf_assert)           Value: 0x7f00000c
ValVar14()                     Value: 0
-----------------------------------------
```

When in the C++ version, the address next to each `ObjVar` would be `& addressMask`, being something like `ObjVar2 (0x7f000002)`. This PR aligns both outputs.

Tested on dryrun cases, confirmed that the outputs for both C++ and Python for `printExprValues` are the same.