### PR TITLE
Harden Assignment 3 release documentation and public checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,4 @@ jobs:
       - name: validate-assignment-3-release
         run: |
           bash scripts/check-assignment-3-release.sh .
+          python3 Assignment-3/Tests/test-reporter-contract.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,6 @@ jobs:
           echo "Z3_DIR="$Z3_DIR
           cmake .
           make
+      - name: validate-assignment-3-release
+        run: |
+          bash scripts/check-assignment-3-release.sh .

--- a/Assignment-3/CPP/AEHelper.cpp
+++ b/Assignment-3/CPP/AEHelper.cpp
@@ -134,6 +134,7 @@ void AbstractExecution::ensureAllAssertsValidated() {
 	static const Set<std::string> kCheckpointStubs = {
 	    "UNSAFE_PTRDEREF", "SAFE_PTRDEREF",
 	    "UNSAFE_BUFACCESS", "SAFE_BUFACCESS"};
+	Set<std::string> checkpointedReportKinds;
 	for (auto it = svfir->getICFG()->begin(); it != svfir->getICFG()->end(); ++it) {
 		const ICFGNode* node = it->second;
 		const CallICFGNode* call = SVFUtil::dyn_cast<CallICFGNode>(node);
@@ -147,6 +148,10 @@ void AbstractExecution::ensureAllAssertsValidated() {
 		const bool isCheckpointStub = kCheckpointStubs.count(name) > 0;
 		if (!isAssertStub && !isCheckpointStub)
 			continue;
+		if (name.find("BUFACCESS") != std::string::npos)
+			checkpointedReportKinds.insert("buffer-overflow");
+		else if (name.find("PTRDEREF") != std::string::npos)
+			checkpointedReportKinds.insert("nullptr-deref");
 		if (!bugReporter.isAssertionPoint(call)) {
 			std::stringstream ss;
 			ss << "The stub function callsite (" << name
@@ -160,6 +165,8 @@ void AbstractExecution::ensureAllAssertsValidated() {
 	static const std::vector<std::string> kReportKinds = {
 	    "buffer-overflow", "nullptr-deref"};
 	for (const std::string& kind : kReportKinds) {
+		if (checkpointedReportKinds.count(kind) == 0)
+			continue;
 		const u32_t expected = bugReporter.getExpectedReportCount(kind);
 		const u32_t actual = bugReporter.getReportCount(kind);
 		if (actual != expected) {
@@ -177,9 +184,9 @@ void AbstractExecution::handleCheckpointStubs(const CallICFGNode* callNode) {
 	bugReporter.noteAssertionPoint(callNode);
 	const std::string fun_name = callNode->getCalledFunction()->getName();
 	if (fun_name == "UNSAFE_BUFACCESS")
-		bugReporter.noteExpectedReport("buffer-overflow");
+		bugReporter.noteExpectedReport("buffer-overflow", callNode);
 	else if (fun_name == "UNSAFE_PTRDEREF")
-		bugReporter.noteExpectedReport("nullptr-deref");
+		bugReporter.noteExpectedReport("nullptr-deref", callNode);
 }
 
 /// Handle the abstract-state assertion stubs.  `svf_assert(expr)` requires the

--- a/Assignment-3/CPP/AEHelper.cpp
+++ b/Assignment-3/CPP/AEHelper.cpp
@@ -128,14 +128,12 @@ void AbstractExecution::initWTO() {
 ///   - UNSAFE_PTRDEREF / SAFE_PTRDEREF    : null-deref ground truth
 ///   - UNSAFE_BUFACCESS / SAFE_BUFACCESS  : buffer-access ground truth
 ///
-/// Additionally requires that the number of reported bugs is at least the
-/// number of UNSAFE_* stubs in the program.
+/// Additionally requires exact report counts for each checkpoint bug kind.
 void AbstractExecution::ensureAllAssertsValidated() {
 	static const Set<std::string> kAssertStubs = {"svf_assert", "svf_assert_eq"};
 	static const Set<std::string> kCheckpointStubs = {
 	    "UNSAFE_PTRDEREF", "SAFE_PTRDEREF",
 	    "UNSAFE_BUFACCESS", "SAFE_BUFACCESS"};
-	u32_t unsafe_to_be_verified = 0;
 	for (auto it = svfir->getICFG()->begin(); it != svfir->getICFG()->end(); ++it) {
 		const ICFGNode* node = it->second;
 		const CallICFGNode* call = SVFUtil::dyn_cast<CallICFGNode>(node);
@@ -149,8 +147,6 @@ void AbstractExecution::ensureAllAssertsValidated() {
 		const bool isCheckpointStub = kCheckpointStubs.count(name) > 0;
 		if (!isAssertStub && !isCheckpointStub)
 			continue;
-		if (name.rfind("UNSAFE_", 0) == 0)
-			unsafe_to_be_verified++;
 		if (!bugReporter.isAssertionPoint(call)) {
 			std::stringstream ss;
 			ss << "The stub function callsite (" << name
@@ -161,84 +157,29 @@ void AbstractExecution::ensureAllAssertsValidated() {
 		}
 	}
 
-	assert(unsafe_to_be_verified <= bugReporter.getBugReporter().getBugSet().size() &&
-		       "The number of UNSAFE_* stubs (ground truth) should <= the number of bugs reported");
-}
-
-// ---------------------------------------------------------------------------
-// Ground-truth helpers used by handleCheckpointStubs.  Computed from SVF
-// primitives only so the stub verdict cannot be biased by student bugs.
-// ---------------------------------------------------------------------------
-
-namespace {
-bool harnessSafeAccess(AbstractState& as, SVFIR* svfir, const ValVar* value,
-                       const IntervalValue& len) {
-	AbstractValue ptrVal = as[value->getId()];
-	if (!ptrVal.isAddr())
-		return true;
-	for (const auto& addr : ptrVal.getAddrs()) {
-		if (AbstractState::isBlackHoleObjAddr(addr) || AbstractState::isNullMem(addr))
-			continue;
-		NodeID objId = as.getIDFromAddr(addr);
-		const BaseObjVar* baseObj = svfir->getBaseObject(objId);
-		if (!baseObj || baseObj->isBlackHoleObj() || !baseObj->isConstantByteSize())
-			continue;
-		u32_t size = baseObj->getByteSizeOfObj();
-		IntervalValue baseOffset(0);
-		const SVFVar* svfVar = svfir->getGNode(objId);
-		if (auto* gepObj = SVFUtil::dyn_cast<GepObjVar>(svfVar))
-			baseOffset = IntervalValue((s64_t)gepObj->getConstantFieldIdx());
-		IntervalValue offset = baseOffset + len;
-		if (offset.ub().getIntNumeral() >= (s64_t)size)
-			return false;
+	static const std::vector<std::string> kReportKinds = {
+	    "buffer-overflow", "nullptr-deref"};
+	for (const std::string& kind : kReportKinds) {
+		const u32_t expected = bugReporter.getExpectedReportCount(kind);
+		const u32_t actual = bugReporter.getReportCount(kind);
+		if (actual != expected) {
+			std::cerr << "Assignment 3 report-count mismatch for " << kind
+			          << ": expected " << expected << ", got " << actual
+			          << std::endl;
+			assert(false && "Assignment 3 report count did not match checkpoints");
+		}
 	}
-	return true;
 }
 
-bool harnessSafeDeref(AbstractState& as, const ValVar* value) {
-	if (!value || value->getId() == IRGraph::NullPtr)
-		return false;
-	const AbstractValue& absVal = as[value->getId()];
-	if (!absVal.isAddr())
-		return true;
-	for (const auto& addr : absVal.getAddrs()) {
-		if (AbstractState::isBlackHoleObjAddr(addr))
-			continue;
-		if (AbstractState::isNullMem(addr))
-			return false;
-		if (as.isFreedMem(addr))
-			return false;
-	}
-	return true;
-}
-} // namespace
-
-/// Validate the SAFE/UNSAFE checkpoint stub functions.  Validation uses the
-/// harness-only `harnessSafeAccess` / `harnessSafeDeref` helpers, NOT the
-/// student's `canSafelyAccessMemory` / `canSafelyDerefPtr` — so the stub
-/// verdict cannot be biased by student bugs.
+/// Record SAFE/UNSAFE checkpoint expectations. The checkpoint does not inspect
+/// abstract state or emit a bug; only the student's checker may report one.
 void AbstractExecution::handleCheckpointStubs(const CallICFGNode* callNode) {
 	bugReporter.noteAssertionPoint(callNode);
 	const std::string fun_name = callNode->getCalledFunction()->getName();
-	if (fun_name == "SAFE_BUFACCESS" || fun_name == "UNSAFE_BUFACCESS") {
-		if (callNode->arg_size() < 2)
-			return;
-		AEState& as = getAEState(callNode);
-		IntervalValue len = as[callNode->getArgument(1)->getId()].getInterval();
-		if (len.isBottom())
-			len = IntervalValue(0);
-		const ValVar* ptr = callNode->getArgument(0);
-		if (!harnessSafeAccess(as, svfir, ptr, len - IntervalValue(1)))
-			reportBufOverflow(callNode);
-	}
-	else if (fun_name == "SAFE_PTRDEREF" || fun_name == "UNSAFE_PTRDEREF") {
-		if (callNode->arg_size() < 1)
-			return;
-		AEState& as = getAEState(callNode);
-		const ValVar* ptr = callNode->getArgument(0);
-		if (!harnessSafeDeref(as, ptr))
-			reportNullDeref(callNode);
-	}
+	if (fun_name == "UNSAFE_BUFACCESS")
+		bugReporter.noteExpectedReport("buffer-overflow");
+	else if (fun_name == "UNSAFE_PTRDEREF")
+		bugReporter.noteExpectedReport("nullptr-deref");
 }
 
 /// Handle the abstract-state assertion stubs.  `svf_assert(expr)` requires the

--- a/Assignment-3/CPP/AEReporter.h
+++ b/Assignment-3/CPP/AEReporter.h
@@ -85,12 +85,14 @@ namespace SVF {
 
 		/// Checkpoint bookkeeping. UNSAFE_* stubs record an expected report
 		/// kind; the checkpoint itself never creates a student bug report.
-		void noteExpectedReport(const std::string& kind) {
-			expectedReportCounts[kind]++;
+		void noteExpectedReport(const std::string& kind,
+		                        const CallICFGNode* checkpoint) {
+			expectedReportPoints[kind].insert(checkpoint);
 		}
 		u32_t getExpectedReportCount(const std::string& kind) const {
-			auto it = expectedReportCounts.find(kind);
-			return it == expectedReportCounts.end() ? 0 : it->second;
+			auto it = expectedReportPoints.find(kind);
+			return it == expectedReportPoints.end()
+			       ? 0 : static_cast<u32_t>(it->second.size());
 		}
 
 		bool hasTargetReport() const;
@@ -116,8 +118,10 @@ namespace SVF {
 
 			std::string loc = eventStack.back().getEventLoc(); // Get the location of the last event in the stack
 
-			// Check if the bug at this location has already been reported
-			const std::string dedupKey = kind + ":" + loc;
+			// Deduplicate the same bug kind at the same analysis node. Keep
+			// different kinds at one node as distinct reports.
+			const std::string dedupKey =
+			    kind + ":" + std::to_string(node ? node->getId() : 0);
 			if (_bugLoc.find(dedupKey) != _bugLoc.end()) {
 				return; // If the bug location is already reported, return early
 			}
@@ -185,7 +189,7 @@ namespace SVF {
 		AssignmentCaseConfig caseConfig;
 		Set<const ICFGNode*> analyzedNodes;
 		Set<const CallICFGNode*> assert_points;
-		Map<std::string, u32_t> expectedReportCounts;
+		Map<std::string, Set<const CallICFGNode*>> expectedReportPoints;
 	};
 
 } // namespace SVF

--- a/Assignment-3/CPP/AEReporter.h
+++ b/Assignment-3/CPP/AEReporter.h
@@ -83,6 +83,16 @@ namespace SVF {
 			return assert_points.find(call) != assert_points.end();
 		}
 
+		/// Checkpoint bookkeeping. UNSAFE_* stubs record an expected report
+		/// kind; the checkpoint itself never creates a student bug report.
+		void noteExpectedReport(const std::string& kind) {
+			expectedReportCounts[kind]++;
+		}
+		u32_t getExpectedReportCount(const std::string& kind) const {
+			auto it = expectedReportCounts.find(kind);
+			return it == expectedReportCounts.end() ? 0 : it->second;
+		}
+
 		bool hasTargetReport() const;
 		void writeJsonSummary(std::ostream& os, const ICFG* icfg,
 		                      double wallSeconds, int exitCode,
@@ -150,6 +160,15 @@ namespace SVF {
 			return static_cast<u32_t>(_reports.size());
 		}
 
+		u32_t getReportCount(const std::string& kind) const {
+			u32_t count = 0;
+			for (const AssignmentBugReport& report : _reports) {
+				if (report.kind == kind)
+					count++;
+			}
+			return count;
+		}
+
 		SVFBugReport& getBugReporter() {
 			return _recoder;
 		}
@@ -166,6 +185,7 @@ namespace SVF {
 		AssignmentCaseConfig caseConfig;
 		Set<const ICFGNode*> analyzedNodes;
 		Set<const CallICFGNode*> assert_points;
+		Map<std::string, u32_t> expectedReportCounts;
 	};
 
 } // namespace SVF

--- a/Assignment-3/Python/AEHelper.py
+++ b/Assignment-3/Python/AEHelper.py
@@ -445,9 +445,11 @@ class AbstractExecution:
         self.buf_overflow_helper.noteAssertionPoint(callNode)
         fun_name = callNode.getCalledFunction().getName()
         if fun_name == "UNSAFE_BUFACCESS":
-            self.buf_overflow_helper.noteExpectedReport("buffer-overflow")
+            self.buf_overflow_helper.noteExpectedReport(
+                "buffer-overflow", callNode)
         elif fun_name == "UNSAFE_PTRDEREF":
-            self.buf_overflow_helper.noteExpectedReport("nullptr-deref")
+            self.buf_overflow_helper.noteExpectedReport(
+                "nullptr-deref", callNode)
 
 
     # mergeStatesFromPredecessors is a student TODO this year and lives in
@@ -484,6 +486,7 @@ class AbstractExecution:
         assert_stubs = {"svf_assert", "svf_assert_eq"}
         checkpoint_stubs = {"UNSAFE_PTRDEREF", "SAFE_PTRDEREF",
                             "UNSAFE_BUFACCESS", "SAFE_BUFACCESS"}
+        checkpointed_report_kinds = set()
         for node in self.svfir.getICFG().getNodes():
             if not isinstance(node, pysvf.CallICFGNode):
                 continue
@@ -493,12 +496,18 @@ class AbstractExecution:
             name = called_function.getName()
             if name not in assert_stubs and name not in checkpoint_stubs:
                 continue
+            if "BUFACCESS" in name:
+                checkpointed_report_kinds.add("buffer-overflow")
+            elif "PTRDEREF" in name:
+                checkpointed_report_kinds.add("nullptr-deref")
             if not self.buf_overflow_helper.isAssertionPoint(node):
                 raise AssertionError(
                     f"The stub function callsite ({name}) was not reached by "
                     f"the student's control flow: {node}"
                 )
         for kind in ("buffer-overflow", "nullptr-deref"):
+            if kind not in checkpointed_report_kinds:
+                continue
             expected = self.buf_overflow_helper.getExpectedReportCount(kind)
             actual = self.buf_overflow_helper.getReportCount(kind)
             if actual != expected:

--- a/Assignment-3/Python/AEHelper.py
+++ b/Assignment-3/Python/AEHelper.py
@@ -435,67 +435,19 @@ class AbstractExecution:
 
 
     def handleCheckpointStubs(self, callNode: pysvf.CallICFGNode):
-        """SAFE_/UNSAFE_ checkpoints: ground-truth bug markers.
+        """Record SAFE_/UNSAFE_ checkpoint reachability and expectations.
 
         Records the call site in ``assert_points`` so
         :py:meth:`ensureAllAssertsValidated` can verify the student's control
-        flow reached it.  The harness reports a bug iff its independent
-        ground-truth check (bypassing the student's predicates) sees one.
+        flow reached it. The checkpoint never inspects state or reports a bug;
+        only the student's checker may create a report.
         """
         self.buf_overflow_helper.noteAssertionPoint(callNode)
         fun_name = callNode.getCalledFunction().getName()
-        abstract_state = self.post_abs_trace[callNode]
-        if fun_name in ("SAFE_BUFACCESS", "UNSAFE_BUFACCESS"):
-            if callNode.arg_size() < 2:
-                return
-            length = abstract_state[callNode.getArgument(1).getId()].getInterval()
-            if length.isBottom():
-                length = IntervalValue(0)
-            ptr = callNode.getArgument(0)
-            if not self._harnessSafeAccess(abstract_state, ptr, length - IntervalValue(1)):
-                self.buf_overflow_helper.reportBufOverflow(
-                    callNode, f"buffer-overflow at {callNode}")
-        elif fun_name in ("SAFE_PTRDEREF", "UNSAFE_PTRDEREF"):
-            if callNode.arg_size() < 1:
-                return
-            ptr = callNode.getArgument(0)
-            if not self._harnessSafeDeref(abstract_state, ptr):
-                self.buf_overflow_helper.reportBufOverflow(
-                    callNode, f"nullptr-deref at {callNode}")
-
-    def _harnessSafeAccess(self, abstract_state, value, length: IntervalValue) -> bool:
-        ptr_val = abstract_state[value.getId()]
-        if not ptr_val.isAddr():
-            return True
-        for addr in ptr_val.getAddrs():
-            if pysvf.AbstractState.isBlackHoleObjAddr(addr) or pysvf.AbstractState.isNullMem(addr):
-                continue
-            obj_id = abstract_state.getIDFromAddr(addr)
-            base_obj = self.svfir.getBaseObject(obj_id)
-            if base_obj is None or base_obj.isBlackHoleObj() or not base_obj.isConstantByteSize():
-                continue
-            size = base_obj.getByteSizeOfObj()
-            gnode = self.svfir.getGNode(obj_id)
-            base_offset = IntervalValue(gnode.getConstantFieldIdx()) if isinstance(gnode, pysvf.GepObjVar) else IntervalValue(0)
-            offset = base_offset + length
-            if int(offset.ub()) >= size:
-                return False
-        return True
-
-    def _harnessSafeDeref(self, abstract_state, value) -> bool:
-        if value is None or isinstance(value, pysvf.ConstNullPtrValVar):
-            return False
-        abs_val = abstract_state[value.getId()]
-        if not abs_val.isAddr():
-            return True
-        for addr in abs_val.getAddrs():
-            if pysvf.AbstractState.isBlackHoleObjAddr(addr):
-                continue
-            if pysvf.AbstractState.isNullMem(addr):
-                return False
-            if abstract_state.isFreedMem(addr):
-                return False
-        return True
+        if fun_name == "UNSAFE_BUFACCESS":
+            self.buf_overflow_helper.noteExpectedReport("buffer-overflow")
+        elif fun_name == "UNSAFE_PTRDEREF":
+            self.buf_overflow_helper.noteExpectedReport("nullptr-deref")
 
 
     # mergeStatesFromPredecessors is a student TODO this year and lives in
@@ -526,13 +478,12 @@ class AbstractExecution:
           * ``UNSAFE_BUFACCESS`` / ``SAFE_BUFACCESS`` -- buffer-access ground truth
 
         A missed stub site means the student's control-flow logic skipped a
-        place the grader cares about.  Additionally requires that the number
-        of reported bugs is at least the number of ``UNSAFE_*`` stubs.
+        place the grader cares about. Report counts must match the reached
+        ``UNSAFE_*`` expectations exactly and independently for each kind.
         """
         assert_stubs = {"svf_assert", "svf_assert_eq"}
         checkpoint_stubs = {"UNSAFE_PTRDEREF", "SAFE_PTRDEREF",
                             "UNSAFE_BUFACCESS", "SAFE_BUFACCESS"}
-        unsafe_to_be_verified = 0
         for node in self.svfir.getICFG().getNodes():
             if not isinstance(node, pysvf.CallICFGNode):
                 continue
@@ -542,15 +493,18 @@ class AbstractExecution:
             name = called_function.getName()
             if name not in assert_stubs and name not in checkpoint_stubs:
                 continue
-            if name.startswith("UNSAFE_"):
-                unsafe_to_be_verified += 1
             if not self.buf_overflow_helper.isAssertionPoint(node):
                 raise AssertionError(
                     f"The stub function callsite ({name}) was not reached by "
                     f"the student's control flow: {node}"
                 )
-        assert unsafe_to_be_verified <= len(self.buf_overflow_helper.node_to_bug_info), \
-            "The number of UNSAFE_* stubs (ground truth) should <= the number of bugs reported"
+        for kind in ("buffer-overflow", "nullptr-deref"):
+            expected = self.buf_overflow_helper.getExpectedReportCount(kind)
+            actual = self.buf_overflow_helper.getReportCount(kind)
+            if actual != expected:
+                raise AssertionError(
+                    f"Assignment 3 report-count mismatch for {kind}: "
+                    f"expected {expected}, got {actual}")
 
 
 

--- a/Assignment-3/Python/AEReporter.py
+++ b/Assignment-3/Python/AEReporter.py
@@ -18,17 +18,26 @@ class AEReporter:
     """
 
     def __init__(self, svfir: pysvf.SVFIR):
-        # Map ICFGNode -> diagnostic message for each detected bug.
+        # Map (kind, ICFGNode) -> diagnostic message. A single access may
+        # legitimately have reports of different kinds.
         self.node_to_bug_info = {}
         self.svfir = svfir
         # Harness bookkeeping: stub call sites the analysis actually reached.
         self.assert_points = set()
+        self.expected_report_counts = {}
 
     def noteAssertionPoint(self, call):
         self.assert_points.add(call)
 
     def isAssertionPoint(self, call) -> bool:
         return call in self.assert_points
+
+    def noteExpectedReport(self, kind: str):
+        self.expected_report_counts[kind] = (
+            self.expected_report_counts.get(kind, 0) + 1)
+
+    def getExpectedReportCount(self, kind: str) -> int:
+        return self.expected_report_counts.get(kind, 0)
 
     def getByteOffset(self, abstract_state: pysvf.AbstractState, gep: pysvf.GepStmt) -> pysvf.IntervalValue:
         return AEState(unwrap_state(abstract_state)).getGepByteOffset(gep)
@@ -51,8 +60,20 @@ class AEReporter:
     def getAllocaInstByteSize(self, abstract_state: pysvf.AbstractState, addr: pysvf.AddrStmt) -> int:
         return AEState(unwrap_state(abstract_state)).getAllocaInstByteSize(addr)
 
+    def reportBug(self, kind: str, node, msg):
+        self.node_to_bug_info.setdefault((kind, node), msg)
+
     def reportBufOverflow(self, node, msg):
-        self.node_to_bug_info[node] = msg
+        self.reportBug("buffer-overflow", node, msg)
+
+    def reportNullDeref(self, node, msg):
+        self.reportBug("nullptr-deref", node, msg)
+
+    def getReportCount(self, kind=None) -> int:
+        if kind is None:
+            return len(self.node_to_bug_info)
+        return sum(1 for report_kind, _ in self.node_to_bug_info
+                   if report_kind == kind)
 
     def printReport(self):
         if not self.node_to_bug_info:
@@ -60,8 +81,9 @@ class AEReporter:
         print("###################### Bug Reports ({} total) ######################".format(
             len(self.node_to_bug_info)))
         print("---------------------------------------------")
-        for node, msg in self.node_to_bug_info.items():
-            print(f"{node}: {msg}\n---------------------------------------------")
+        for (kind, node), msg in self.node_to_bug_info.items():
+            print(f"[{kind}] {node}: {msg}\n"
+                  "---------------------------------------------")
 
     def getElementSize(self, var: pysvf.SVFVar) -> int:
         if var.getType().isArrayTy():

--- a/Assignment-3/Python/AEReporter.py
+++ b/Assignment-3/Python/AEReporter.py
@@ -24,7 +24,7 @@ class AEReporter:
         self.svfir = svfir
         # Harness bookkeeping: stub call sites the analysis actually reached.
         self.assert_points = set()
-        self.expected_report_counts = {}
+        self.expected_report_points = {}
 
     def noteAssertionPoint(self, call):
         self.assert_points.add(call)
@@ -32,12 +32,11 @@ class AEReporter:
     def isAssertionPoint(self, call) -> bool:
         return call in self.assert_points
 
-    def noteExpectedReport(self, kind: str):
-        self.expected_report_counts[kind] = (
-            self.expected_report_counts.get(kind, 0) + 1)
+    def noteExpectedReport(self, kind: str, checkpoint):
+        self.expected_report_points.setdefault(kind, set()).add(checkpoint)
 
     def getExpectedReportCount(self, kind: str) -> int:
-        return self.expected_report_counts.get(kind, 0)
+        return len(self.expected_report_points.get(kind, ()))
 
     def getByteOffset(self, abstract_state: pysvf.AbstractState, gep: pysvf.GepStmt) -> pysvf.IntervalValue:
         return AEState(unwrap_state(abstract_state)).getGepByteOffset(gep)

--- a/Assignment-3/Python/Assignment_3.py
+++ b/Assignment-3/Python/Assignment_3.py
@@ -76,7 +76,7 @@ class Assignment3(AbstractExecution):
             node, msg if msg is not None else f"buffer-overflow at {node}")
 
     def reportNullDeref(self, node, msg=None):
-        self.buf_overflow_helper.reportBufOverflow(
+        self.buf_overflow_helper.reportNullDeref(
             node, msg if msg is not None else f"nullptr-deref at {node}")
 
     # =========================================================================

--- a/Assignment-3/Python/CMakeLists.txt
+++ b/Assignment-3/Python/CMakeLists.txt
@@ -1,5 +1,15 @@
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
+add_test(
+        NAME ass3-harness-py/reporter-contract
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/../Tests/test-reporter-contract.py
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(ass3-harness-py/reporter-contract PROPERTIES
+        TIMEOUT 30
+        LABELS "ass3;ass3-harness;python")
+
 # loops over ae_assert_files and run "ae $bc_file"
 file(GLOB ae_assert_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../Tests "${CMAKE_CURRENT_SOURCE_DIR}/../Tests/ae/*.ll")
 foreach(filename ${ae_assert_files})

--- a/Assignment-3/README.md
+++ b/Assignment-3/README.md
@@ -117,10 +117,10 @@ range. The destination is also checked as a write and the source as a read.
 | `memcpy(dst, src, n)` | Copy `n` bytes from `src` to `dst`; return `dst`. |
 | `memmove(dst, src, n)` | As `memcpy`, but read the source values before writing overlapping destinations; return `dst`. |
 | `memset(dst, value, n)` | Store the low byte of `value` into `n` bytes at `dst`; return `dst`. |
-| `strcpy(dst, src)` | Copy `strlen(src)` modelled bytes from offset 0; return `dst`. |
-| `strncpy(dst, src, n)` | Copy `n` modelled bytes from offset 0; return `dst`. |
-| `strcat(dst, src)` | Copy `strlen(src)` modelled bytes at destination offset `strlen(dst)`; return `dst`. |
-| `strncat(dst, src, n)` | Copy `n` modelled bytes at destination offset `strlen(dst)`; return `dst`. |
+| `strcpy(dst, src)` | Copy `strlen(src) + 1` bytes, including the null terminator, from offset 0; return `dst`. |
+| `strncpy(dst, src, n)` | Copy exactly `n` bytes from offset 0, padding with null bytes when the source is shorter; return `dst`. |
+| `strcat(dst, src)` | Copy `strlen(src) + 1` bytes, including the terminator, at destination offset `strlen(dst)`; return `dst`. |
+| `strncat(dst, src, n)` | Copy at most `n` non-null source bytes at destination offset `strlen(dst)`, then append a null terminator; return `dst`. |
 | `strlen(src)` | Return an interval containing the possible index of the first null byte. |
 | `wcslen(src)` | As `strlen`, measured in wide-character elements. |
 | `mem_insert(buffer, data, data_size, position)` | Copy `data_size` bytes from `data` to `buffer + position`. |
@@ -180,8 +180,10 @@ Checkpoints are ground-truth expectation markers, not detector
 implementations. Every marker must be reachable. Each `UNSAFE_BUFACCESS`
 records one expected `buffer-overflow` report and each `UNSAFE_PTRDEREF`
 records one expected `nullptr-deref` report. Safe markers add no expected
-report. At case completion, the harness compares expected and actual counts
-exactly and separately by kind. Consequently:
+report. For each bug kind represented by at least one checkpoint in a case,
+the harness compares expected and actual counts exactly. A real-program case
+with no checkpoint for a kind may still emit reports of that kind.
+Consequently:
 
 - an unsafe marker passes only when student analysis reports a real unsafe
   access;
@@ -189,7 +191,8 @@ exactly and separately by kind. Consequently:
 - a report of the wrong kind fails; and
 - an extra report, including a report at a safe access, fails.
 
-Duplicate reports of the same kind and source location are counted once.
+Duplicate reports of the same kind at the same ICFG node are counted once.
+Different bug kinds at one node remain separate reports.
 
 ## Build and run
 

--- a/Assignment-3/README.md
+++ b/Assignment-3/README.md
@@ -1,0 +1,300 @@
+# Assignment 3: Abstract Execution
+
+This document is the versioned, authoritative contract for Assignment 3.
+The [course wiki](https://github.com/SVF-tools/Software-Security-Analysis/wiki/Assignment-3)
+provides navigation and API reference material. If a wiki page and this file
+disagree about the assignment, follow this file from the repository revision
+you are using.
+
+## Deliverables
+
+Implement an abstract executor over SVF's interval and address-set domains.
+It must analyse interprocedural control flow, model the listed external APIs,
+and detect buffer overflows and null-pointer dereferences.
+
+| Language | Files accepted for submission |
+| --- | --- |
+| C++ | `Assignment_3.cpp` and `Assignment_3.h` |
+| Python | `Assignment_3.py` |
+
+You may add helpers inside the accepted files. The other files under
+`Assignment-3/` are supplied infrastructure and are replaced during marking.
+
+The harness starts `analyse()` and calls, directly or indirectly, these five
+student entry points:
+
+| Entry point | Required responsibility |
+| --- | --- |
+| `handleGlobalNode` | Initialise and execute the global ICFG node. |
+| `handleFunction` | Walk a function's interprocedural WTO components. |
+| `handleICFGNode` | Merge incoming state, execute the node, run checkers, and return whether its post-state changed. |
+| `handleICFGCycle` | Compute a terminating loop or recursive-SCC fixpoint. |
+| `handleCallSite` | Dispatch stubs, external calls, ordinary calls, and recursive calls. |
+
+You may choose a different internal decomposition, but every reachable node,
+assertion, and checkpoint must be handled.
+
+## Required tasks and semantics
+
+### 1. Statement transfer functions
+
+Initialise global and allocated objects, then dispatch every statement on the
+current ICFG node. The required abstract effects are:
+
+| Statement family | Required effect |
+| --- | --- |
+| Address | Bind the result to the abstract address of its object; initialise allocated object memory. |
+| Copy and cast | Copy the source abstract value to the result without changing its value kind. |
+| Binary and comparison | Apply the corresponding abstract interval operator. |
+| Load | Read the joined value of every address represented by the pointer. |
+| Store | Write the value through every represented address. |
+| GEP | Add the abstract byte offset to every represented base address. |
+| Phi and select | Join only values from feasible incoming alternatives. |
+| Call parameter | Propagate the actual value to its formal parameter. |
+| Return parameter | Propagate the callee's return value to the caller's result. |
+
+Preserve explicit null addresses. Do not silently convert an address set to an
+interval or an interval to an address set. Use the supplied `AEState` and
+abstract-execution helpers rather than maintaining a second, inconsistent
+memory model.
+
+### 2. Branch feasibility
+
+For each incoming edge:
+
+1. Clone the predecessor post-state.
+2. For a conditional or switch edge, meet the condition interval with the
+   edge's required value.
+3. Discard the cloned state if the meet is bottom.
+4. Join all remaining states.
+
+Keep branch refinements local to that edge. Preserve the function-entry
+pre-state if no ordinary predecessor state is available. Phi values must use
+only feasible incoming paths.
+
+### 3. Cycle and recursion fixpoint
+
+Walk the supplied WTO in order. Handle singleton components once and cycle
+components with the following policy:
+
+```text
+old_head = bottom
+for iteration = 0, 1, ...:
+    execute the cycle head and body in WTO order
+    new_head = current head state
+    if new_head == old_head:
+        break
+    if iteration >= widen_delay:
+        store widening(old_head, new_head) at the head
+    old_head = stored head state
+
+repeat in WTO order using narrowing(old_head, new_head)
+until the head state no longer changes
+```
+
+Use `Options::WidenDelay()` in C++ and `self.widen_delay` in Python. Apply the
+same mechanism to loops and recursive call-graph SCCs. Nested cycles are
+visited in WTO order. Iteration must terminate; the harness imposes an
+emergency cap of 10,000 cycle iterations.
+
+Python state ownership is significant: `clone()`, `widening()`, and
+`narrowing()` return raw `pysvf.AbstractState` objects. Wrap a cloned raw
+state in `AEState` before placing it in `pre_abs_trace` or
+`post_abs_trace`; do not keep a mutable trace alias as an iteration snapshot.
+
+### 4. External-API summaries
+
+`handleCallSite` must dispatch assertion/checkpoint stubs first, then
+`nd`/`rand`, the supported external functions, ordinary callees, and
+recursive call sites. `nd` and `rand` return top.
+
+For the table below, `dst`, `src`, `n`, and `pos` denote the corresponding
+call arguments. A copy transfers the abstract byte values in the indicated
+range. The destination is also checked as a write and the source as a read.
+
+| Function | Required value/memory summary |
+| --- | --- |
+| `memcpy(dst, src, n)` | Copy `n` bytes from `src` to `dst`; return `dst`. |
+| `memmove(dst, src, n)` | As `memcpy`, but read the source values before writing overlapping destinations; return `dst`. |
+| `memset(dst, value, n)` | Store the low byte of `value` into `n` bytes at `dst`; return `dst`. |
+| `strcpy(dst, src)` | Copy `strlen(src)` modelled bytes from offset 0; return `dst`. |
+| `strncpy(dst, src, n)` | Copy `n` modelled bytes from offset 0; return `dst`. |
+| `strcat(dst, src)` | Copy `strlen(src)` modelled bytes at destination offset `strlen(dst)`; return `dst`. |
+| `strncat(dst, src, n)` | Copy `n` modelled bytes at destination offset `strlen(dst)`; return `dst`. |
+| `strlen(src)` | Return an interval containing the possible index of the first null byte. |
+| `wcslen(src)` | As `strlen`, measured in wide-character elements. |
+| `mem_insert(buffer, data, data_size, position)` | Copy `data_size` bytes from `data` to `buffer + position`. |
+| `str_insert(buffer, data, position)` | Copy `strlen(data)` bytes from `data` to `buffer + position`. |
+
+If a size, length, or position is an interval, conservatively join the effects
+of its possible range. If it is unknown, do not invent a precise constant.
+An unlisted external call has no assignment-specific summary: leave the
+abstract state unchanged and do not invent a return value.
+
+Run the null and bounds checkers on pointer arguments dereferenced by a
+summary. At minimum:
+
+| Operation | Pointer arguments dereferenced |
+| --- | --- |
+| `memcpy`, `memmove`, `strcpy`, `strncpy`, `strcat`, `strncat` | destination and source |
+| `memset` | destination |
+| `strlen`, `wcslen` | source |
+| `mem_insert`, `str_insert` | buffer and data |
+
+### 5. Buffer-overflow checker
+
+Check direct load, store, and GEP accesses plus the external operations above.
+For every possible concrete target object:
+
+1. obtain the base object and its byte size;
+2. accumulate the pointer's byte offset from that base;
+3. include the access length in the accessed byte range; and
+4. report if the lower bound can be below zero or the upper bound can be at
+   least the object size.
+
+Do not report a scalar that is not an address. If the target is null,
+black-hole, or has unknown size, leave that target to the null/unknown policy
+instead of inventing a buffer size. Report the actual access node with
+`reportBufOverflow(node)`.
+
+### 6. Null-pointer-dereference checker
+
+Check the pointer operand of loads, stores, GEPs, and supported external
+operations. A pointer is unsafe if its address set may contain the null
+address or an address recorded as freed. A black-hole address alone is
+unknown, not proof of null. Branch refinement may establish a pointer as
+non-null.
+
+Report the actual dereference node with `reportNullDeref(node)`. For an
+external operation, report its call node.
+
+## Assertions, checkpoints, and reports
+
+The public cases use `svf_assert`, `svf_assert_eq`, and these checkpoint
+stubs:
+
+- `SAFE_BUFACCESS` / `UNSAFE_BUFACCESS`
+- `SAFE_PTRDEREF` / `UNSAFE_PTRDEREF`
+
+Checkpoints are ground-truth expectation markers, not detector
+implementations. Every marker must be reachable. Each `UNSAFE_BUFACCESS`
+records one expected `buffer-overflow` report and each `UNSAFE_PTRDEREF`
+records one expected `nullptr-deref` report. Safe markers add no expected
+report. At case completion, the harness compares expected and actual counts
+exactly and separately by kind. Consequently:
+
+- an unsafe marker passes only when student analysis reports a real unsafe
+  access;
+- a missed report fails;
+- a report of the wrong kind fails; and
+- an extra report, including a report at a safe access, fails.
+
+Duplicate reports of the same kind and source location are counted once.
+
+## Build and run
+
+Commands below are run from the repository root. Choose the build layout that
+matches your checkout:
+
+```bash
+# A normal out-of-source checkout:
+BUILD_DIR=build
+
+# The supplied Docker image is already configured in source:
+# BUILD_DIR=.
+```
+
+Build the C++ implementation:
+
+```bash
+cmake --build "$BUILD_DIR" --target ass3 -j8
+```
+
+Run all registered public Level-1 cases:
+
+```bash
+ctest --test-dir "$BUILD_DIR" \
+  -R '^ass3-level-1-cpp/' --output-on-failure
+
+ctest --test-dir "$BUILD_DIR" \
+  -R '^ass3-level-1-py/' --output-on-failure
+
+# Both languages:
+ctest --test-dir "$BUILD_DIR" \
+  -L ass3-level-1 --output-on-failure
+```
+
+Run one case directly:
+
+```bash
+"$BUILD_DIR/bin/ass3" \
+  Assignment-3/Tests/level-1/01-stmt-basic.ll
+
+python3 Assignment-3/Python/test-ae.py \
+  Assignment-3/Tests/level-1/01-stmt-basic.ll
+```
+
+CMake gives each public C++ case 120 seconds and each public Python case 180
+seconds. These commands run all *registered public Level-1 cases*, not the
+complete assignment marking suite. The Level-2 fixture is intentionally run
+directly because of its memory use; see
+[Tests/README.md](Tests/README.md).
+
+### Write an additional case
+
+Write a small C program that declares the needed stubs, exercises one
+property, and places a checkpoint after the real access. Compile with the
+course's LLVM 21 `clang`:
+
+```bash
+clang -g -O0 -fno-discard-value-names -fno-builtin \
+  -S -emit-llvm my-case.c -o my-case.ll
+
+"$BUILD_DIR/bin/ass3" my-case.ll
+python3 Assignment-3/Python/test-ae.py my-case.ll
+```
+
+Keep cases deterministic and feature-focused. Do not replace the real
+operation with only an `UNSAFE_*` marker.
+
+## Assessment
+
+Assignment 3 is worth 100 points:
+
+| Level | Points | Assessed capability |
+| --- | ---: | --- |
+| Level 1 | 30 | Individual abstract-execution and checker features. |
+| Level 2 | 40 | End-to-end analysis of active real-program fixtures. |
+| Level 3 | 30 | Large-program execution, target detection, and report precision. |
+
+Public examples support development; they are not the complete marking suite.
+Hidden case counts, per-case weights, and marking timeouts are controlled by
+the marking environment and are not published.
+
+For Levels 2 and 3:
+
+- **target detection** means reporting the ground-truth unsafe operation;
+- **report precision** distinguishes target reports from non-target reports;
+- **completion** means finishing without a crash, failed assertion, or
+  timeout; and
+- **coverage**, when shown by the harness, is the percentage of reachable
+  ICFG nodes analysed.
+
+Passing every public test does not guarantee a particular mark.
+
+## Submit
+
+Submit from the directory containing the implementation. File names are
+case-sensitive:
+
+```bash
+# C++
+give cs6131 ass3 Assignment_3.cpp Assignment_3.h
+
+# Python
+give cs6131 ass3 Assignment_3.py
+```
+
+For C++, both files are required. A successful submission reports
+`Your submission is ACCEPTED.` You may resubmit before the deadline; only the
+latest accepted submission is marked.

--- a/Assignment-3/Tests/GRADING.md
+++ b/Assignment-3/Tests/GRADING.md
@@ -15,7 +15,7 @@ number, distribution, and per-case weights are not published.
 The published Level 1 examples cover the following primary features. A public
 example passes when it exits normally, reaches every `svf_assert` and
 checkpoint, validates every assertion, and produces exactly the expected
-report count for each bug kind.
+report count for each bug kind represented by a checkpoint in that case.
 
 | Published example | Primary feature |
 | --- | --- |
@@ -23,7 +23,7 @@ report count for each bug kind.
 | `02-branch-feasible` | Branch feasibility |
 | `03-buffer-overflow` | Real out-of-bounds access detection |
 | `04-nullptr-deref` | Real null-pointer-dereference detection |
-| `05-loop-fixpoint` | Loop widening and narrowing |
+| `05-loop-fixpoint` | Loop fixpoint and widening |
 | `06-recursion-fixpoint` | Recursive-SCC fixpoint |
 | `07-interprocedural-call-return` | Actual/formal and return propagation |
 | `08-memory-summary` | Memory external-call summaries |

--- a/Assignment-3/Tests/GRADING.md
+++ b/Assignment-3/Tests/GRADING.md
@@ -13,15 +13,25 @@ number, distribution, and per-case weights are not published.
 ## Level 1
 
 The published Level 1 examples cover the following primary features. A public
-example passes when it exits normally and all of its `svf_assert` or
-`UNSAFE_*` checkpoints have the expected result.
+example passes when it exits normally, reaches every `svf_assert` and
+checkpoint, validates every assertion, and produces exactly the expected
+report count for each bug kind.
 
 | Published example | Primary feature |
 | --- | --- |
 | `01-stmt-basic` | SVF statement transfer |
 | `02-branch-feasible` | Branch feasibility |
-| `03-buffer-overflow` | Buffer-overflow detection |
-| `04-nullptr-deref` | Null-pointer-dereference detection |
+| `03-buffer-overflow` | Real out-of-bounds access detection |
+| `04-nullptr-deref` | Real null-pointer-dereference detection |
+| `05-loop-fixpoint` | Loop widening and narrowing |
+| `06-recursion-fixpoint` | Recursive-SCC fixpoint |
+| `07-interprocedural-call-return` | Actual/formal and return propagation |
+| `08-memory-summary` | Memory external-call summaries |
+| `09-string-summary` | String external-call summaries |
+| `10-safe-memory` | Safe-access report precision |
+
+The public CTest timeout is 120 seconds per C++ case and 180 seconds per
+Python case.
 
 ## Level 2
 
@@ -43,3 +53,17 @@ Level 3 marking runs are subject to a timeout.
 
 The published Level 2 example is not registered in CTest because of its memory
 use. Run it directly as described in `README.md`.
+
+For Levels 2 and 3:
+
+- target detection means reporting the ground-truth unsafe operation;
+- report precision distinguishes target reports from non-target reports;
+- completion means finishing without a crash, failed assertion, or timeout;
+  and
+- coverage, when displayed, is the percentage of reachable ICFG nodes
+  analysed.
+
+Hidden case counts, weights, and timeouts are controlled by the marking
+environment and are not published. Passing every public case does not
+guarantee a particular mark. The complete semantic and checkpoint contract is
+in [`Assignment-3/README.md`](../README.md).

--- a/Assignment-3/Tests/README.md
+++ b/Assignment-3/Tests/README.md
@@ -21,7 +21,7 @@ The published examples are:
 | `02-branch-feasible` | Branch feasibility |
 | `03-buffer-overflow` | Real out-of-bounds access detection |
 | `04-nullptr-deref` | Real null-pointer-dereference detection |
-| `05-loop-fixpoint` | Loop widening and narrowing |
+| `05-loop-fixpoint` | Loop fixpoint and widening |
 | `06-recursion-fixpoint` | Recursive-SCC fixpoint |
 | `07-interprocedural-call-return` | Actual/formal and return propagation |
 | `08-memory-summary` | Memory external-call summaries |

--- a/Assignment-3/Tests/README.md
+++ b/Assignment-3/Tests/README.md
@@ -19,24 +19,51 @@ The published examples are:
 | --- | --- |
 | `01-stmt-basic` | SVF statement transfer |
 | `02-branch-feasible` | Branch feasibility |
-| `03-buffer-overflow` | Buffer-overflow detection |
-| `04-nullptr-deref` | Null-pointer-dereference detection |
+| `03-buffer-overflow` | Real out-of-bounds access detection |
+| `04-nullptr-deref` | Real null-pointer-dereference detection |
+| `05-loop-fixpoint` | Loop widening and narrowing |
+| `06-recursion-fixpoint` | Recursive-SCC fixpoint |
+| `07-interprocedural-call-return` | Actual/formal and return propagation |
+| `08-memory-summary` | Memory external-call summaries |
+| `09-string-summary` | String external-call summaries |
+| `10-safe-memory` | Safe-access report precision |
 
-After configuring and building the repository, run both implementations with:
+From the repository root, set `BUILD_DIR` to your configured CMake build tree:
 
 ```bash
-ctest --test-dir Release-build -L ass3-level-1 --output-on-failure
+# Normal out-of-source build:
+BUILD_DIR=build
+
+# Supplied Docker checkout:
+# BUILD_DIR=.
+```
+
+Run all registered public Level-1 cases:
+
+```bash
+ctest --test-dir "$BUILD_DIR" \
+  -R '^ass3-level-1-cpp/' --output-on-failure
+
+ctest --test-dir "$BUILD_DIR" \
+  -R '^ass3-level-1-py/' --output-on-failure
+
+# Both implementations:
+ctest --test-dir "$BUILD_DIR" \
+  -L ass3-level-1 --output-on-failure
 ```
 
 Run one case directly:
 
 ```bash
-Release-build/bin/ass3 \
+"$BUILD_DIR/bin/ass3" \
   Assignment-3/Tests/level-1/01-stmt-basic.ll
 
 python3 Assignment-3/Python/test-ae.py \
   Assignment-3/Tests/level-1/01-stmt-basic.ll
 ```
+
+CMake enforces a 120-second timeout per public C++ case and a 180-second
+timeout per public Python case.
 
 ## Level 2
 
@@ -44,7 +71,7 @@ Level 2 is intentionally excluded from CTest because of its memory use. Run
 both implementations directly from the repository root:
 
 ```bash
-Release-build/bin/ass3 \
+"$BUILD_DIR/bin/ass3" \
   Assignment-3/Tests/level-2/repro.ll
 
 python3 Assignment-3/Python/test-ae.py \
@@ -53,3 +80,7 @@ python3 Assignment-3/Python/test-ae.py \
 
 Level 3 assesses large-program execution and report precision. No Level-3
 fixture is published in this repository.
+
+See the authoritative [Assignment 3 contract](../README.md) for required
+semantics, checkpoint behaviour, assessment definitions, and submission
+instructions.

--- a/Assignment-3/Tests/level-1/03-buffer-overflow.c
+++ b/Assignment-3/Tests/level-1/03-buffer-overflow.c
@@ -2,6 +2,9 @@ extern void UNSAFE_BUFACCESS(void *, unsigned long);
 
 int main(void) {
     char buf[1] = {0};
-    UNSAFE_BUFACCESS(&buf[1], 1);
+    volatile char *unsafe = &buf[1];
+    volatile char observed = *unsafe;
+    (void)observed;
+    UNSAFE_BUFACCESS((void *)unsafe, 1);
     return 0;
 }

--- a/Assignment-3/Tests/level-1/03-buffer-overflow.c
+++ b/Assignment-3/Tests/level-1/03-buffer-overflow.c
@@ -2,9 +2,8 @@ extern void UNSAFE_BUFACCESS(void *, unsigned long);
 
 int main(void) {
     char buf[1] = {0};
-    volatile char *unsafe = &buf[1];
-    volatile char observed = *unsafe;
+    volatile int observed = *(volatile int *)(void *)buf;
     (void)observed;
-    UNSAFE_BUFACCESS((void *)unsafe, 1);
+    UNSAFE_BUFACCESS((void *)buf, sizeof(int));
     return 0;
 }

--- a/Assignment-3/Tests/level-1/03-buffer-overflow.ll
+++ b/Assignment-3/Tests/level-1/03-buffer-overflow.ll
@@ -4,26 +4,22 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i6
 target triple = "aarch64-unknown-linux-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define dso_local i32 @main() #0 !dbg !12 {
+define dso_local i32 @main() #0 !dbg !15 {
 entry:
   %retval = alloca i32, align 4
   %buf = alloca [1 x i8], align 1
-  %unsafe = alloca ptr, align 8
-  %observed = alloca i8, align 1
+  %observed = alloca i32, align 4
   store i32 0, ptr %retval, align 4
-    #dbg_declare(ptr %buf, !17, !DIExpression(), !22)
-  call void @llvm.memset.p0.i64(ptr align 1 %buf, i8 0, i64 1, i1 false), !dbg !22
-    #dbg_declare(ptr %unsafe, !23, !DIExpression(), !26)
-  %arrayidx = getelementptr inbounds [1 x i8], ptr %buf, i64 0, i64 1, !dbg !27
-  store ptr %arrayidx, ptr %unsafe, align 8, !dbg !26
-    #dbg_declare(ptr %observed, !28, !DIExpression(), !29)
-  %0 = load ptr, ptr %unsafe, align 8, !dbg !30
-  %1 = load volatile i8, ptr %0, align 1, !dbg !31
-  store volatile i8 %1, ptr %observed, align 1, !dbg !29
-  %2 = load volatile i8, ptr %observed, align 1, !dbg !32
-  %3 = load ptr, ptr %unsafe, align 8, !dbg !33
-  call void @UNSAFE_BUFACCESS(ptr noundef %3, i64 noundef 1) #3, !dbg !34
-  ret i32 0, !dbg !35
+    #dbg_declare(ptr %buf, !19, !DIExpression(), !24)
+  call void @llvm.memset.p0.i64(ptr align 1 %buf, i8 0, i64 1, i1 false), !dbg !24
+    #dbg_declare(ptr %observed, !25, !DIExpression(), !26)
+  %arraydecay = getelementptr inbounds [1 x i8], ptr %buf, i64 0, i64 0, !dbg !27
+  %0 = load volatile i32, ptr %arraydecay, align 4, !dbg !28
+  store volatile i32 %0, ptr %observed, align 4, !dbg !26
+  %1 = load volatile i32, ptr %observed, align 4, !dbg !29
+  %arraydecay1 = getelementptr inbounds [1 x i8], ptr %buf, i64 0, i64 0, !dbg !30
+  call void @UNSAFE_BUFACCESS(ptr noundef %arraydecay1, i64 noundef 4) #3, !dbg !31
+  ret i32 0, !dbg !32
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
@@ -37,42 +33,39 @@ attributes #2 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="t
 attributes #3 = { nobuiltin "no-builtins" }
 
 !llvm.dbg.cu = !{!0}
-!llvm.module.flags = !{!4, !5, !6, !7, !8, !9, !10}
-!llvm.ident = !{!11}
+!llvm.module.flags = !{!7, !8, !9, !10, !11, !12, !13}
+!llvm.ident = !{!14}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !2, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "03-buffer-overflow.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "da36a99d6f2e7e8f3d7c061ced18a972")
-!2 = !{!3}
-!3 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
-!4 = !{i32 7, !"Dwarf Version", i32 5}
-!5 = !{i32 2, !"Debug Info Version", i32 3}
-!6 = !{i32 1, !"wchar_size", i32 4}
-!7 = !{i32 8, !"PIC Level", i32 2}
-!8 = !{i32 7, !"PIE Level", i32 2}
-!9 = !{i32 7, !"uwtable", i32 2}
-!10 = !{i32 7, !"frame-pointer", i32 1}
-!11 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
-!12 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !16)
-!13 = !DISubroutineType(types: !14)
-!14 = !{!15}
-!15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!16 = !{}
-!17 = !DILocalVariable(name: "buf", scope: !12, file: !1, line: 4, type: !18)
-!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 8, elements: !20)
-!19 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
-!20 = !{!21}
-!21 = !DISubrange(count: 1)
-!22 = !DILocation(line: 4, column: 10, scope: !12)
-!23 = !DILocalVariable(name: "unsafe", scope: !12, file: !1, line: 5, type: !24)
-!24 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !19)
-!26 = !DILocation(line: 5, column: 20, scope: !12)
-!27 = !DILocation(line: 5, column: 30, scope: !12)
-!28 = !DILocalVariable(name: "observed", scope: !12, file: !1, line: 6, type: !25)
-!29 = !DILocation(line: 6, column: 19, scope: !12)
-!30 = !DILocation(line: 6, column: 31, scope: !12)
-!31 = !DILocation(line: 6, column: 30, scope: !12)
-!32 = !DILocation(line: 7, column: 11, scope: !12)
-!33 = !DILocation(line: 8, column: 30, scope: !12)
-!34 = !DILocation(line: 8, column: 5, scope: !12)
-!35 = !DILocation(line: 9, column: 5, scope: !12)
+!1 = !DIFile(filename: "03-buffer-overflow.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "11a2826ffe4359ef566adcbe40a679b1")
+!2 = !{!3, !6}
+!3 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!4 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !5)
+!5 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+!7 = !{i32 7, !"Dwarf Version", i32 5}
+!8 = !{i32 2, !"Debug Info Version", i32 3}
+!9 = !{i32 1, !"wchar_size", i32 4}
+!10 = !{i32 8, !"PIC Level", i32 2}
+!11 = !{i32 7, !"PIE Level", i32 2}
+!12 = !{i32 7, !"uwtable", i32 2}
+!13 = !{i32 7, !"frame-pointer", i32 1}
+!14 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
+!15 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !16, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !18)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!5}
+!18 = !{}
+!19 = !DILocalVariable(name: "buf", scope: !15, file: !1, line: 4, type: !20)
+!20 = !DICompositeType(tag: DW_TAG_array_type, baseType: !21, size: 8, elements: !22)
+!21 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
+!22 = !{!23}
+!23 = !DISubrange(count: 1)
+!24 = !DILocation(line: 4, column: 10, scope: !15)
+!25 = !DILocalVariable(name: "observed", scope: !15, file: !1, line: 5, type: !4)
+!26 = !DILocation(line: 5, column: 18, scope: !15)
+!27 = !DILocation(line: 5, column: 54, scope: !15)
+!28 = !DILocation(line: 5, column: 29, scope: !15)
+!29 = !DILocation(line: 6, column: 11, scope: !15)
+!30 = !DILocation(line: 7, column: 30, scope: !15)
+!31 = !DILocation(line: 7, column: 5, scope: !15)
+!32 = !DILocation(line: 8, column: 5, scope: !15)

--- a/Assignment-3/Tests/level-1/03-buffer-overflow.ll
+++ b/Assignment-3/Tests/level-1/03-buffer-overflow.ll
@@ -4,16 +4,26 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i6
 target triple = "aarch64-unknown-linux-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define dso_local i32 @main() #0 !dbg !10 {
+define dso_local i32 @main() #0 !dbg !12 {
 entry:
   %retval = alloca i32, align 4
   %buf = alloca [1 x i8], align 1
+  %unsafe = alloca ptr, align 8
+  %observed = alloca i8, align 1
   store i32 0, ptr %retval, align 4
-    #dbg_declare(ptr %buf, !15, !DIExpression(), !20)
-  call void @llvm.memset.p0.i64(ptr align 1 %buf, i8 0, i64 1, i1 false), !dbg !20
-  %arrayidx = getelementptr inbounds [1 x i8], ptr %buf, i64 0, i64 1, !dbg !21
-  call void @UNSAFE_BUFACCESS(ptr noundef %arrayidx, i64 noundef 1), !dbg !22
-  ret i32 0, !dbg !23
+    #dbg_declare(ptr %buf, !17, !DIExpression(), !22)
+  call void @llvm.memset.p0.i64(ptr align 1 %buf, i8 0, i64 1, i1 false), !dbg !22
+    #dbg_declare(ptr %unsafe, !23, !DIExpression(), !26)
+  %arrayidx = getelementptr inbounds [1 x i8], ptr %buf, i64 0, i64 1, !dbg !27
+  store ptr %arrayidx, ptr %unsafe, align 8, !dbg !26
+    #dbg_declare(ptr %observed, !28, !DIExpression(), !29)
+  %0 = load ptr, ptr %unsafe, align 8, !dbg !30
+  %1 = load volatile i8, ptr %0, align 1, !dbg !31
+  store volatile i8 %1, ptr %observed, align 1, !dbg !29
+  %2 = load volatile i8, ptr %observed, align 1, !dbg !32
+  %3 = load ptr, ptr %unsafe, align 8, !dbg !33
+  call void @UNSAFE_BUFACCESS(ptr noundef %3, i64 noundef 1) #3, !dbg !34
+  ret i32 0, !dbg !35
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
@@ -21,35 +31,48 @@ declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immar
 
 declare void @UNSAFE_BUFACCESS(ptr noundef, i64 noundef) #2
 
-attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #2 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #3 = { nobuiltin "no-builtins" }
 
 !llvm.dbg.cu = !{!0}
-!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
-!llvm.ident = !{!9}
+!llvm.module.flags = !{!4, !5, !6, !7, !8, !9, !10}
+!llvm.ident = !{!11}
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "03-buffer-overflow.c", directory: ".", checksumkind: CSK_MD5, checksum: "9aaf7853a32fe73b43d66fde4884f191")
-!2 = !{i32 7, !"Dwarf Version", i32 5}
-!3 = !{i32 2, !"Debug Info Version", i32 3}
-!4 = !{i32 1, !"wchar_size", i32 4}
-!5 = !{i32 8, !"PIC Level", i32 2}
-!6 = !{i32 7, !"PIE Level", i32 2}
-!7 = !{i32 7, !"uwtable", i32 2}
-!8 = !{i32 7, !"frame-pointer", i32 1}
-!9 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
-!10 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !11, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
-!11 = !DISubroutineType(types: !12)
-!12 = !{!13}
-!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!14 = !{}
-!15 = !DILocalVariable(name: "buf", scope: !10, file: !1, line: 4, type: !16)
-!16 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 8, elements: !18)
-!17 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
-!18 = !{!19}
-!19 = !DISubrange(count: 1)
-!20 = !DILocation(line: 4, column: 10, scope: !10)
-!21 = !DILocation(line: 5, column: 23, scope: !10)
-!22 = !DILocation(line: 5, column: 5, scope: !10)
-!23 = !DILocation(line: 6, column: 5, scope: !10)
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "03-buffer-overflow.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "da36a99d6f2e7e8f3d7c061ced18a972")
+!2 = !{!3}
+!3 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+!4 = !{i32 7, !"Dwarf Version", i32 5}
+!5 = !{i32 2, !"Debug Info Version", i32 3}
+!6 = !{i32 1, !"wchar_size", i32 4}
+!7 = !{i32 8, !"PIC Level", i32 2}
+!8 = !{i32 7, !"PIE Level", i32 2}
+!9 = !{i32 7, !"uwtable", i32 2}
+!10 = !{i32 7, !"frame-pointer", i32 1}
+!11 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
+!12 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !16)
+!13 = !DISubroutineType(types: !14)
+!14 = !{!15}
+!15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!16 = !{}
+!17 = !DILocalVariable(name: "buf", scope: !12, file: !1, line: 4, type: !18)
+!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 8, elements: !20)
+!19 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
+!20 = !{!21}
+!21 = !DISubrange(count: 1)
+!22 = !DILocation(line: 4, column: 10, scope: !12)
+!23 = !DILocalVariable(name: "unsafe", scope: !12, file: !1, line: 5, type: !24)
+!24 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !19)
+!26 = !DILocation(line: 5, column: 20, scope: !12)
+!27 = !DILocation(line: 5, column: 30, scope: !12)
+!28 = !DILocalVariable(name: "observed", scope: !12, file: !1, line: 6, type: !25)
+!29 = !DILocation(line: 6, column: 19, scope: !12)
+!30 = !DILocation(line: 6, column: 31, scope: !12)
+!31 = !DILocation(line: 6, column: 30, scope: !12)
+!32 = !DILocation(line: 7, column: 11, scope: !12)
+!33 = !DILocation(line: 8, column: 30, scope: !12)
+!34 = !DILocation(line: 8, column: 5, scope: !12)
+!35 = !DILocation(line: 9, column: 5, scope: !12)

--- a/Assignment-3/Tests/level-1/04-nullptr-deref.c
+++ b/Assignment-3/Tests/level-1/04-nullptr-deref.c
@@ -1,6 +1,9 @@
 extern void UNSAFE_PTRDEREF(void *);
 
 int main(void) {
-    UNSAFE_PTRDEREF((void *)0);
+    volatile int *ptr = (volatile int *)0;
+    volatile int observed = *ptr;
+    (void)observed;
+    UNSAFE_PTRDEREF((void *)ptr);
     return 0;
 }

--- a/Assignment-3/Tests/level-1/04-nullptr-deref.ll
+++ b/Assignment-3/Tests/level-1/04-nullptr-deref.ll
@@ -4,38 +4,60 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i6
 target triple = "aarch64-unknown-linux-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define dso_local i32 @main() #0 !dbg !12 {
+define dso_local i32 @main() #0 !dbg !15 {
 entry:
   %retval = alloca i32, align 4
+  %ptr = alloca ptr, align 8
+  %observed = alloca i32, align 4
   store i32 0, ptr %retval, align 4
-  call void @UNSAFE_PTRDEREF(ptr noundef null), !dbg !16
-  ret i32 0, !dbg !17
+    #dbg_declare(ptr %ptr, !19, !DIExpression(), !20)
+  store ptr null, ptr %ptr, align 8, !dbg !20
+    #dbg_declare(ptr %observed, !21, !DIExpression(), !22)
+  %0 = load ptr, ptr %ptr, align 8, !dbg !23
+  %1 = load volatile i32, ptr %0, align 4, !dbg !24
+  store volatile i32 %1, ptr %observed, align 4, !dbg !22
+  %2 = load volatile i32, ptr %observed, align 4, !dbg !25
+  %3 = load ptr, ptr %ptr, align 8, !dbg !26
+  call void @UNSAFE_PTRDEREF(ptr noundef %3) #2, !dbg !27
+  ret i32 0, !dbg !28
 }
 
 declare void @UNSAFE_PTRDEREF(ptr noundef) #1
 
-attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
-attributes #1 = { "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #1 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #2 = { nobuiltin "no-builtins" }
 
 !llvm.dbg.cu = !{!0}
-!llvm.module.flags = !{!4, !5, !6, !7, !8, !9, !10}
-!llvm.ident = !{!11}
+!llvm.module.flags = !{!7, !8, !9, !10, !11, !12, !13}
+!llvm.ident = !{!14}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !2, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "04-nullptr-deref.c", directory: ".", checksumkind: CSK_MD5, checksum: "76d9226d6f1c970c2f50fd260a0d923d")
-!2 = !{!3}
-!3 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
-!4 = !{i32 7, !"Dwarf Version", i32 5}
-!5 = !{i32 2, !"Debug Info Version", i32 3}
-!6 = !{i32 1, !"wchar_size", i32 4}
-!7 = !{i32 8, !"PIC Level", i32 2}
-!8 = !{i32 7, !"PIE Level", i32 2}
-!9 = !{i32 7, !"uwtable", i32 2}
-!10 = !{i32 7, !"frame-pointer", i32 1}
-!11 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
-!12 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !13, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
-!13 = !DISubroutineType(types: !14)
-!14 = !{!15}
-!15 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!16 = !DILocation(line: 4, column: 5, scope: !12)
-!17 = !DILocation(line: 5, column: 5, scope: !12)
+!1 = !DIFile(filename: "04-nullptr-deref.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "029a96a2ae8851f5ad370ed7ecc944d0")
+!2 = !{!3, !6}
+!3 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!4 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !5)
+!5 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+!7 = !{i32 7, !"Dwarf Version", i32 5}
+!8 = !{i32 2, !"Debug Info Version", i32 3}
+!9 = !{i32 1, !"wchar_size", i32 4}
+!10 = !{i32 8, !"PIC Level", i32 2}
+!11 = !{i32 7, !"PIE Level", i32 2}
+!12 = !{i32 7, !"uwtable", i32 2}
+!13 = !{i32 7, !"frame-pointer", i32 1}
+!14 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
+!15 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 3, type: !16, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !18)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!5}
+!18 = !{}
+!19 = !DILocalVariable(name: "ptr", scope: !15, file: !1, line: 4, type: !3)
+!20 = !DILocation(line: 4, column: 19, scope: !15)
+!21 = !DILocalVariable(name: "observed", scope: !15, file: !1, line: 5, type: !4)
+!22 = !DILocation(line: 5, column: 18, scope: !15)
+!23 = !DILocation(line: 5, column: 30, scope: !15)
+!24 = !DILocation(line: 5, column: 29, scope: !15)
+!25 = !DILocation(line: 6, column: 11, scope: !15)
+!26 = !DILocation(line: 7, column: 29, scope: !15)
+!27 = !DILocation(line: 7, column: 5, scope: !15)
+!28 = !DILocation(line: 8, column: 5, scope: !15)

--- a/Assignment-3/Tests/level-1/05-loop-fixpoint.c
+++ b/Assignment-3/Tests/level-1/05-loop-fixpoint.c
@@ -1,12 +1,13 @@
 #include <stdbool.h>
 
 extern void svf_assert(bool);
+extern int nd(void);
 
 int main(void) {
     int value = 0;
-    while (value < 10) {
+    while (nd()) {
         value++;
     }
-    svf_assert(value == 10);
+    svf_assert(value >= 0);
     return 0;
 }

--- a/Assignment-3/Tests/level-1/05-loop-fixpoint.c
+++ b/Assignment-3/Tests/level-1/05-loop-fixpoint.c
@@ -1,0 +1,12 @@
+#include <stdbool.h>
+
+extern void svf_assert(bool);
+
+int main(void) {
+    int value = 0;
+    while (value < 10) {
+        value++;
+    }
+    svf_assert(value == 10);
+    return 0;
+}

--- a/Assignment-3/Tests/level-1/05-loop-fixpoint.ll
+++ b/Assignment-3/Tests/level-1/05-loop-fixpoint.ll
@@ -14,22 +14,24 @@ entry:
   br label %while.cond, !dbg !17
 
 while.cond:                                       ; preds = %while.body, %entry
-  %0 = load i32, ptr %value, align 4, !dbg !18
-  %cmp = icmp slt i32 %0, 10, !dbg !19
-  br i1 %cmp, label %while.body, label %while.end, !dbg !17
+  %call = call i32 @nd() #2, !dbg !18
+  %tobool = icmp ne i32 %call, 0, !dbg !17
+  br i1 %tobool, label %while.body, label %while.end, !dbg !17
 
 while.body:                                       ; preds = %while.cond
-  %1 = load i32, ptr %value, align 4, !dbg !20
-  %inc = add nsw i32 %1, 1, !dbg !20
-  store i32 %inc, ptr %value, align 4, !dbg !20
-  br label %while.cond, !dbg !17, !llvm.loop !22
+  %0 = load i32, ptr %value, align 4, !dbg !19
+  %inc = add nsw i32 %0, 1, !dbg !19
+  store i32 %inc, ptr %value, align 4, !dbg !19
+  br label %while.cond, !dbg !17, !llvm.loop !21
 
 while.end:                                        ; preds = %while.cond
-  %2 = load i32, ptr %value, align 4, !dbg !25
-  %cmp1 = icmp eq i32 %2, 10, !dbg !26
-  call void @svf_assert(i1 noundef %cmp1) #2, !dbg !27
-  ret i32 0, !dbg !28
+  %1 = load i32, ptr %value, align 4, !dbg !24
+  %cmp = icmp sge i32 %1, 0, !dbg !25
+  call void @svf_assert(i1 noundef %cmp) #2, !dbg !26
+  ret i32 0, !dbg !27
 }
+
+declare i32 @nd() #1
 
 declare void @svf_assert(i1 noundef) #1
 
@@ -42,7 +44,7 @@ attributes #2 = { nobuiltin "no-builtins" }
 !llvm.ident = !{!9}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "05-loop-fixpoint.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "ac29527a76233e895ce54f261138a204")
+!1 = !DIFile(filename: "05-loop-fixpoint.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "f6a23e56553b381e71ec18c9adf9e8b1")
 !2 = !{i32 7, !"Dwarf Version", i32 5}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = !{i32 1, !"wchar_size", i32 4}
@@ -51,22 +53,21 @@ attributes #2 = { nobuiltin "no-builtins" }
 !7 = !{i32 7, !"uwtable", i32 2}
 !8 = !{i32 7, !"frame-pointer", i32 1}
 !9 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
-!10 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!10 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 6, type: !11, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
 !11 = !DISubroutineType(types: !12)
 !12 = !{!13}
 !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 !14 = !{}
-!15 = !DILocalVariable(name: "value", scope: !10, file: !1, line: 6, type: !13)
-!16 = !DILocation(line: 6, column: 9, scope: !10)
-!17 = !DILocation(line: 7, column: 5, scope: !10)
-!18 = !DILocation(line: 7, column: 12, scope: !10)
-!19 = !DILocation(line: 7, column: 18, scope: !10)
-!20 = !DILocation(line: 8, column: 14, scope: !21)
-!21 = distinct !DILexicalBlock(scope: !10, file: !1, line: 7, column: 24)
-!22 = distinct !{!22, !17, !23, !24}
-!23 = !DILocation(line: 9, column: 5, scope: !10)
-!24 = !{!"llvm.loop.mustprogress"}
-!25 = !DILocation(line: 10, column: 16, scope: !10)
-!26 = !DILocation(line: 10, column: 22, scope: !10)
-!27 = !DILocation(line: 10, column: 5, scope: !10)
-!28 = !DILocation(line: 11, column: 5, scope: !10)
+!15 = !DILocalVariable(name: "value", scope: !10, file: !1, line: 7, type: !13)
+!16 = !DILocation(line: 7, column: 9, scope: !10)
+!17 = !DILocation(line: 8, column: 5, scope: !10)
+!18 = !DILocation(line: 8, column: 12, scope: !10)
+!19 = !DILocation(line: 9, column: 14, scope: !20)
+!20 = distinct !DILexicalBlock(scope: !10, file: !1, line: 8, column: 18)
+!21 = distinct !{!21, !17, !22, !23}
+!22 = !DILocation(line: 10, column: 5, scope: !10)
+!23 = !{!"llvm.loop.mustprogress"}
+!24 = !DILocation(line: 11, column: 16, scope: !10)
+!25 = !DILocation(line: 11, column: 22, scope: !10)
+!26 = !DILocation(line: 11, column: 5, scope: !10)
+!27 = !DILocation(line: 12, column: 5, scope: !10)

--- a/Assignment-3/Tests/level-1/05-loop-fixpoint.ll
+++ b/Assignment-3/Tests/level-1/05-loop-fixpoint.ll
@@ -1,0 +1,72 @@
+; ModuleID = '05-loop-fixpoint.c'
+source_filename = "05-loop-fixpoint.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 !dbg !10 {
+entry:
+  %retval = alloca i32, align 4
+  %value = alloca i32, align 4
+  store i32 0, ptr %retval, align 4
+    #dbg_declare(ptr %value, !15, !DIExpression(), !16)
+  store i32 0, ptr %value, align 4, !dbg !16
+  br label %while.cond, !dbg !17
+
+while.cond:                                       ; preds = %while.body, %entry
+  %0 = load i32, ptr %value, align 4, !dbg !18
+  %cmp = icmp slt i32 %0, 10, !dbg !19
+  br i1 %cmp, label %while.body, label %while.end, !dbg !17
+
+while.body:                                       ; preds = %while.cond
+  %1 = load i32, ptr %value, align 4, !dbg !20
+  %inc = add nsw i32 %1, 1, !dbg !20
+  store i32 %inc, ptr %value, align 4, !dbg !20
+  br label %while.cond, !dbg !17, !llvm.loop !22
+
+while.end:                                        ; preds = %while.cond
+  %2 = load i32, ptr %value, align 4, !dbg !25
+  %cmp1 = icmp eq i32 %2, 10, !dbg !26
+  call void @svf_assert(i1 noundef %cmp1) #2, !dbg !27
+  ret i32 0, !dbg !28
+}
+
+declare void @svf_assert(i1 noundef) #1
+
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #1 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #2 = { nobuiltin "no-builtins" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!llvm.ident = !{!9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "05-loop-fixpoint.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "ac29527a76233e895ce54f261138a204")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 1}
+!9 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
+!10 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 5, type: !11, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !{}
+!15 = !DILocalVariable(name: "value", scope: !10, file: !1, line: 6, type: !13)
+!16 = !DILocation(line: 6, column: 9, scope: !10)
+!17 = !DILocation(line: 7, column: 5, scope: !10)
+!18 = !DILocation(line: 7, column: 12, scope: !10)
+!19 = !DILocation(line: 7, column: 18, scope: !10)
+!20 = !DILocation(line: 8, column: 14, scope: !21)
+!21 = distinct !DILexicalBlock(scope: !10, file: !1, line: 7, column: 24)
+!22 = distinct !{!22, !17, !23, !24}
+!23 = !DILocation(line: 9, column: 5, scope: !10)
+!24 = !{!"llvm.loop.mustprogress"}
+!25 = !DILocation(line: 10, column: 16, scope: !10)
+!26 = !DILocation(line: 10, column: 22, scope: !10)
+!27 = !DILocation(line: 10, column: 5, scope: !10)
+!28 = !DILocation(line: 11, column: 5, scope: !10)

--- a/Assignment-3/Tests/level-1/06-recursion-fixpoint.c
+++ b/Assignment-3/Tests/level-1/06-recursion-fixpoint.c
@@ -1,0 +1,16 @@
+#include <stdbool.h>
+
+extern void svf_assert(bool);
+
+static void count_down(int value) {
+    if (value <= 0) {
+        svf_assert(value <= 0);
+        return;
+    }
+    count_down(value - 1);
+}
+
+int main(void) {
+    count_down(3);
+    return 0;
+}

--- a/Assignment-3/Tests/level-1/06-recursion-fixpoint.ll
+++ b/Assignment-3/Tests/level-1/06-recursion-fixpoint.ll
@@ -1,0 +1,84 @@
+; ModuleID = '06-recursion-fixpoint.c'
+source_filename = "06-recursion-fixpoint.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 !dbg !10 {
+entry:
+  %retval = alloca i32, align 4
+  store i32 0, ptr %retval, align 4
+  call void @count_down(i32 noundef 3) #2, !dbg !14
+  ret i32 0, !dbg !15
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal void @count_down(i32 noundef %value) #0 !dbg !16 {
+entry:
+  %value.addr = alloca i32, align 4
+  store i32 %value, ptr %value.addr, align 4
+    #dbg_declare(ptr %value.addr, !20, !DIExpression(), !21)
+  %0 = load i32, ptr %value.addr, align 4, !dbg !22
+  %cmp = icmp sle i32 %0, 0, !dbg !24
+  br i1 %cmp, label %if.then, label %if.end, !dbg !24
+
+if.then:                                          ; preds = %entry
+  %1 = load i32, ptr %value.addr, align 4, !dbg !25
+  %cmp1 = icmp sle i32 %1, 0, !dbg !27
+  call void @svf_assert(i1 noundef %cmp1) #2, !dbg !28
+  br label %return, !dbg !29
+
+if.end:                                           ; preds = %entry
+  %2 = load i32, ptr %value.addr, align 4, !dbg !30
+  %sub = sub nsw i32 %2, 1, !dbg !31
+  call void @count_down(i32 noundef %sub) #2, !dbg !32
+  br label %return, !dbg !33
+
+return:                                           ; preds = %if.end, %if.then
+  ret void, !dbg !33
+}
+
+declare void @svf_assert(i1 noundef) #1
+
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #1 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #2 = { nobuiltin "no-builtins" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!llvm.ident = !{!9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "06-recursion-fixpoint.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "5c0f5c29d1fe6224bb1d5e07fb03ac76")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 1}
+!9 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
+!10 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 13, type: !11, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !DILocation(line: 14, column: 5, scope: !10)
+!15 = !DILocation(line: 15, column: 5, scope: !10)
+!16 = distinct !DISubprogram(name: "count_down", scope: !1, file: !1, line: 5, type: !17, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!17 = !DISubroutineType(types: !18)
+!18 = !{null, !13}
+!19 = !{}
+!20 = !DILocalVariable(name: "value", arg: 1, scope: !16, file: !1, line: 5, type: !13)
+!21 = !DILocation(line: 5, column: 28, scope: !16)
+!22 = !DILocation(line: 6, column: 9, scope: !23)
+!23 = distinct !DILexicalBlock(scope: !16, file: !1, line: 6, column: 9)
+!24 = !DILocation(line: 6, column: 15, scope: !23)
+!25 = !DILocation(line: 7, column: 20, scope: !26)
+!26 = distinct !DILexicalBlock(scope: !23, file: !1, line: 6, column: 21)
+!27 = !DILocation(line: 7, column: 26, scope: !26)
+!28 = !DILocation(line: 7, column: 9, scope: !26)
+!29 = !DILocation(line: 8, column: 9, scope: !26)
+!30 = !DILocation(line: 10, column: 16, scope: !16)
+!31 = !DILocation(line: 10, column: 22, scope: !16)
+!32 = !DILocation(line: 10, column: 5, scope: !16)
+!33 = !DILocation(line: 11, column: 1, scope: !16)

--- a/Assignment-3/Tests/level-1/07-interprocedural-call-return.c
+++ b/Assignment-3/Tests/level-1/07-interprocedural-call-return.c
@@ -1,0 +1,13 @@
+#include <stdbool.h>
+
+extern void svf_assert(bool);
+
+static int add_one(int value) {
+    return value + 1;
+}
+
+int main(void) {
+    int result = add_one(41);
+    svf_assert(result == 42);
+    return 0;
+}

--- a/Assignment-3/Tests/level-1/07-interprocedural-call-return.ll
+++ b/Assignment-3/Tests/level-1/07-interprocedural-call-return.ll
@@ -1,0 +1,71 @@
+; ModuleID = '07-interprocedural-call-return.c'
+source_filename = "07-interprocedural-call-return.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 !dbg !10 {
+entry:
+  %retval = alloca i32, align 4
+  %result = alloca i32, align 4
+  store i32 0, ptr %retval, align 4
+    #dbg_declare(ptr %result, !15, !DIExpression(), !16)
+  %call = call i32 @add_one(i32 noundef 41) #2, !dbg !17
+  store i32 %call, ptr %result, align 4, !dbg !16
+  %0 = load i32, ptr %result, align 4, !dbg !18
+  %cmp = icmp eq i32 %0, 42, !dbg !19
+  call void @svf_assert(i1 noundef %cmp) #2, !dbg !20
+  ret i32 0, !dbg !21
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal i32 @add_one(i32 noundef %value) #0 !dbg !22 {
+entry:
+  %value.addr = alloca i32, align 4
+  store i32 %value, ptr %value.addr, align 4
+    #dbg_declare(ptr %value.addr, !25, !DIExpression(), !26)
+  %0 = load i32, ptr %value.addr, align 4, !dbg !27
+  %add = add nsw i32 %0, 1, !dbg !28
+  ret i32 %add, !dbg !29
+}
+
+declare void @svf_assert(i1 noundef) #1
+
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #1 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #2 = { nobuiltin "no-builtins" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!llvm.ident = !{!9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "07-interprocedural-call-return.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "0ef343c6dc46b77255fecb23f4877a4b")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 1}
+!9 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
+!10 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 9, type: !11, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !{}
+!15 = !DILocalVariable(name: "result", scope: !10, file: !1, line: 10, type: !13)
+!16 = !DILocation(line: 10, column: 9, scope: !10)
+!17 = !DILocation(line: 10, column: 18, scope: !10)
+!18 = !DILocation(line: 11, column: 16, scope: !10)
+!19 = !DILocation(line: 11, column: 23, scope: !10)
+!20 = !DILocation(line: 11, column: 5, scope: !10)
+!21 = !DILocation(line: 12, column: 5, scope: !10)
+!22 = distinct !DISubprogram(name: "add_one", scope: !1, file: !1, line: 5, type: !23, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!23 = !DISubroutineType(types: !24)
+!24 = !{!13, !13}
+!25 = !DILocalVariable(name: "value", arg: 1, scope: !22, file: !1, line: 5, type: !13)
+!26 = !DILocation(line: 5, column: 24, scope: !22)
+!27 = !DILocation(line: 6, column: 12, scope: !22)
+!28 = !DILocation(line: 6, column: 18, scope: !22)
+!29 = !DILocation(line: 6, column: 5, scope: !22)

--- a/Assignment-3/Tests/level-1/08-memory-summary.c
+++ b/Assignment-3/Tests/level-1/08-memory-summary.c
@@ -1,0 +1,15 @@
+#include <stdbool.h>
+#include <stddef.h>
+
+extern void svf_assert(bool);
+extern void *memcpy(void *, const void *, size_t);
+
+int main(void) {
+    unsigned char source[2] = {7, 9};
+    unsigned char destination[2] = {0, 0};
+
+    memcpy(destination, source, 2);
+    svf_assert(destination[0] == 7);
+    svf_assert(destination[1] == 9);
+    return 0;
+}

--- a/Assignment-3/Tests/level-1/08-memory-summary.ll
+++ b/Assignment-3/Tests/level-1/08-memory-summary.ll
@@ -1,0 +1,87 @@
+; ModuleID = '08-memory-summary.c'
+source_filename = "08-memory-summary.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+@__const.main.source = private unnamed_addr constant [2 x i8] c"\07\09", align 1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 !dbg !10 {
+entry:
+  %retval = alloca i32, align 4
+  %source = alloca [2 x i8], align 1
+  %destination = alloca [2 x i8], align 1
+  store i32 0, ptr %retval, align 4
+    #dbg_declare(ptr %source, !15, !DIExpression(), !20)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %source, ptr align 1 @__const.main.source, i64 2, i1 false), !dbg !20
+    #dbg_declare(ptr %destination, !21, !DIExpression(), !22)
+  call void @llvm.memset.p0.i64(ptr align 1 %destination, i8 0, i64 2, i1 false), !dbg !22
+  %arraydecay = getelementptr inbounds [2 x i8], ptr %destination, i64 0, i64 0, !dbg !23
+  %arraydecay1 = getelementptr inbounds [2 x i8], ptr %source, i64 0, i64 0, !dbg !24
+  %call = call ptr @memcpy(ptr noundef %arraydecay, ptr noundef %arraydecay1, i64 noundef 2) #4, !dbg !25
+  %arrayidx = getelementptr inbounds [2 x i8], ptr %destination, i64 0, i64 0, !dbg !26
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !26
+  %conv = zext i8 %0 to i32, !dbg !26
+  %cmp = icmp eq i32 %conv, 7, !dbg !27
+  call void @svf_assert(i1 noundef %cmp) #4, !dbg !28
+  %arrayidx3 = getelementptr inbounds [2 x i8], ptr %destination, i64 0, i64 1, !dbg !29
+  %1 = load i8, ptr %arrayidx3, align 1, !dbg !29
+  %conv4 = zext i8 %1 to i32, !dbg !29
+  %cmp5 = icmp eq i32 %conv4, 9, !dbg !30
+  call void @svf_assert(i1 noundef %cmp5) #4, !dbg !31
+  ret i32 0, !dbg !32
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #2
+
+declare ptr @memcpy(ptr noundef, ptr noundef, i64 noundef) #3
+
+declare void @svf_assert(i1 noundef) #3
+
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #4 = { nobuiltin "no-builtins" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!llvm.ident = !{!9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "08-memory-summary.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "4a6be870c323fee62857605a34465964")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 1}
+!9 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
+!10 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !11, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !{}
+!15 = !DILocalVariable(name: "source", scope: !10, file: !1, line: 8, type: !16)
+!16 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 16, elements: !18)
+!17 = !DIBasicType(name: "unsigned char", size: 8, encoding: DW_ATE_unsigned_char)
+!18 = !{!19}
+!19 = !DISubrange(count: 2)
+!20 = !DILocation(line: 8, column: 19, scope: !10)
+!21 = !DILocalVariable(name: "destination", scope: !10, file: !1, line: 9, type: !16)
+!22 = !DILocation(line: 9, column: 19, scope: !10)
+!23 = !DILocation(line: 11, column: 12, scope: !10)
+!24 = !DILocation(line: 11, column: 25, scope: !10)
+!25 = !DILocation(line: 11, column: 5, scope: !10)
+!26 = !DILocation(line: 12, column: 16, scope: !10)
+!27 = !DILocation(line: 12, column: 31, scope: !10)
+!28 = !DILocation(line: 12, column: 5, scope: !10)
+!29 = !DILocation(line: 13, column: 16, scope: !10)
+!30 = !DILocation(line: 13, column: 31, scope: !10)
+!31 = !DILocation(line: 13, column: 5, scope: !10)
+!32 = !DILocation(line: 14, column: 5, scope: !10)

--- a/Assignment-3/Tests/level-1/09-string-summary.c
+++ b/Assignment-3/Tests/level-1/09-string-summary.c
@@ -7,11 +7,12 @@ extern size_t strlen(const char *);
 
 int main(void) {
     char source[3] = {'a', 'b', '\0'};
-    char destination[8] = {0};
+    char destination[8] = {0, 0, 9, 9, 0, 0, 0, 0};
 
     strcpy(destination, source);
     svf_assert(destination[0] == 'a');
     svf_assert(destination[1] == 'b');
+    svf_assert(destination[2] == '\0');
     svf_assert(strlen(source) == 2);
     return 0;
 }

--- a/Assignment-3/Tests/level-1/09-string-summary.c
+++ b/Assignment-3/Tests/level-1/09-string-summary.c
@@ -1,0 +1,17 @@
+#include <stdbool.h>
+#include <stddef.h>
+
+extern void svf_assert(bool);
+extern char *strcpy(char *, const char *);
+extern size_t strlen(const char *);
+
+int main(void) {
+    char source[3] = {'a', 'b', '\0'};
+    char destination[8] = {0};
+
+    strcpy(destination, source);
+    svf_assert(destination[0] == 'a');
+    svf_assert(destination[1] == 'b');
+    svf_assert(strlen(source) == 2);
+    return 0;
+}

--- a/Assignment-3/Tests/level-1/09-string-summary.ll
+++ b/Assignment-3/Tests/level-1/09-string-summary.ll
@@ -1,0 +1,100 @@
+; ModuleID = '09-string-summary.c'
+source_filename = "09-string-summary.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+@__const.main.source = private unnamed_addr constant [3 x i8] c"ab\00", align 1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 !dbg !10 {
+entry:
+  %retval = alloca i32, align 4
+  %source = alloca [3 x i8], align 1
+  %destination = alloca [8 x i8], align 1
+  store i32 0, ptr %retval, align 4
+    #dbg_declare(ptr %source, !15, !DIExpression(), !20)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %source, ptr align 1 @__const.main.source, i64 3, i1 false), !dbg !20
+    #dbg_declare(ptr %destination, !21, !DIExpression(), !25)
+  call void @llvm.memset.p0.i64(ptr align 1 %destination, i8 0, i64 8, i1 false), !dbg !25
+  %arraydecay = getelementptr inbounds [8 x i8], ptr %destination, i64 0, i64 0, !dbg !26
+  %arraydecay1 = getelementptr inbounds [3 x i8], ptr %source, i64 0, i64 0, !dbg !27
+  %call = call ptr @strcpy(ptr noundef %arraydecay, ptr noundef %arraydecay1) #4, !dbg !28
+  %arrayidx = getelementptr inbounds [8 x i8], ptr %destination, i64 0, i64 0, !dbg !29
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !29
+  %conv = zext i8 %0 to i32, !dbg !29
+  %cmp = icmp eq i32 %conv, 97, !dbg !30
+  call void @svf_assert(i1 noundef %cmp) #4, !dbg !31
+  %arrayidx3 = getelementptr inbounds [8 x i8], ptr %destination, i64 0, i64 1, !dbg !32
+  %1 = load i8, ptr %arrayidx3, align 1, !dbg !32
+  %conv4 = zext i8 %1 to i32, !dbg !32
+  %cmp5 = icmp eq i32 %conv4, 98, !dbg !33
+  call void @svf_assert(i1 noundef %cmp5) #4, !dbg !34
+  %arraydecay7 = getelementptr inbounds [3 x i8], ptr %source, i64 0, i64 0, !dbg !35
+  %call8 = call i64 @strlen(ptr noundef %arraydecay7) #4, !dbg !36
+  %cmp9 = icmp eq i64 %call8, 2, !dbg !37
+  call void @svf_assert(i1 noundef %cmp9) #4, !dbg !38
+  ret i32 0, !dbg !39
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #2
+
+declare ptr @strcpy(ptr noundef, ptr noundef) #3
+
+declare void @svf_assert(i1 noundef) #3
+
+declare i64 @strlen(ptr noundef) #3
+
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #4 = { nobuiltin "no-builtins" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!llvm.ident = !{!9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "09-string-summary.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "c4bbb7985f79dd463b8209db97c3043c")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 1}
+!9 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
+!10 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 8, type: !11, scopeLine: 8, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !14)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13}
+!13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!14 = !{}
+!15 = !DILocalVariable(name: "source", scope: !10, file: !1, line: 9, type: !16)
+!16 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 24, elements: !18)
+!17 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
+!18 = !{!19}
+!19 = !DISubrange(count: 3)
+!20 = !DILocation(line: 9, column: 10, scope: !10)
+!21 = !DILocalVariable(name: "destination", scope: !10, file: !1, line: 10, type: !22)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 8)
+!25 = !DILocation(line: 10, column: 10, scope: !10)
+!26 = !DILocation(line: 12, column: 12, scope: !10)
+!27 = !DILocation(line: 12, column: 25, scope: !10)
+!28 = !DILocation(line: 12, column: 5, scope: !10)
+!29 = !DILocation(line: 13, column: 16, scope: !10)
+!30 = !DILocation(line: 13, column: 31, scope: !10)
+!31 = !DILocation(line: 13, column: 5, scope: !10)
+!32 = !DILocation(line: 14, column: 16, scope: !10)
+!33 = !DILocation(line: 14, column: 31, scope: !10)
+!34 = !DILocation(line: 14, column: 5, scope: !10)
+!35 = !DILocation(line: 15, column: 23, scope: !10)
+!36 = !DILocation(line: 15, column: 16, scope: !10)
+!37 = !DILocation(line: 15, column: 31, scope: !10)
+!38 = !DILocation(line: 15, column: 5, scope: !10)
+!39 = !DILocation(line: 16, column: 5, scope: !10)

--- a/Assignment-3/Tests/level-1/09-string-summary.ll
+++ b/Assignment-3/Tests/level-1/09-string-summary.ll
@@ -4,6 +4,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i6
 target triple = "aarch64-unknown-linux-gnu"
 
 @__const.main.source = private unnamed_addr constant [3 x i8] c"ab\00", align 1
+@__const.main.destination = private unnamed_addr constant [8 x i8] c"\00\00\09\09\00\00\00\00", align 1
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() #0 !dbg !10 {
@@ -15,51 +16,52 @@ entry:
     #dbg_declare(ptr %source, !15, !DIExpression(), !20)
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %source, ptr align 1 @__const.main.source, i64 3, i1 false), !dbg !20
     #dbg_declare(ptr %destination, !21, !DIExpression(), !25)
-  call void @llvm.memset.p0.i64(ptr align 1 %destination, i8 0, i64 8, i1 false), !dbg !25
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %destination, ptr align 1 @__const.main.destination, i64 8, i1 false), !dbg !25
   %arraydecay = getelementptr inbounds [8 x i8], ptr %destination, i64 0, i64 0, !dbg !26
   %arraydecay1 = getelementptr inbounds [3 x i8], ptr %source, i64 0, i64 0, !dbg !27
-  %call = call ptr @strcpy(ptr noundef %arraydecay, ptr noundef %arraydecay1) #4, !dbg !28
+  %call = call ptr @strcpy(ptr noundef %arraydecay, ptr noundef %arraydecay1) #3, !dbg !28
   %arrayidx = getelementptr inbounds [8 x i8], ptr %destination, i64 0, i64 0, !dbg !29
   %0 = load i8, ptr %arrayidx, align 1, !dbg !29
   %conv = zext i8 %0 to i32, !dbg !29
   %cmp = icmp eq i32 %conv, 97, !dbg !30
-  call void @svf_assert(i1 noundef %cmp) #4, !dbg !31
+  call void @svf_assert(i1 noundef %cmp) #3, !dbg !31
   %arrayidx3 = getelementptr inbounds [8 x i8], ptr %destination, i64 0, i64 1, !dbg !32
   %1 = load i8, ptr %arrayidx3, align 1, !dbg !32
   %conv4 = zext i8 %1 to i32, !dbg !32
   %cmp5 = icmp eq i32 %conv4, 98, !dbg !33
-  call void @svf_assert(i1 noundef %cmp5) #4, !dbg !34
-  %arraydecay7 = getelementptr inbounds [3 x i8], ptr %source, i64 0, i64 0, !dbg !35
-  %call8 = call i64 @strlen(ptr noundef %arraydecay7) #4, !dbg !36
-  %cmp9 = icmp eq i64 %call8, 2, !dbg !37
-  call void @svf_assert(i1 noundef %cmp9) #4, !dbg !38
-  ret i32 0, !dbg !39
+  call void @svf_assert(i1 noundef %cmp5) #3, !dbg !34
+  %arrayidx7 = getelementptr inbounds [8 x i8], ptr %destination, i64 0, i64 2, !dbg !35
+  %2 = load i8, ptr %arrayidx7, align 1, !dbg !35
+  %conv8 = zext i8 %2 to i32, !dbg !35
+  %cmp9 = icmp eq i32 %conv8, 0, !dbg !36
+  call void @svf_assert(i1 noundef %cmp9) #3, !dbg !37
+  %arraydecay11 = getelementptr inbounds [3 x i8], ptr %source, i64 0, i64 0, !dbg !38
+  %call12 = call i64 @strlen(ptr noundef %arraydecay11) #3, !dbg !39
+  %cmp13 = icmp eq i64 %call12, 2, !dbg !40
+  call void @svf_assert(i1 noundef %cmp13) #3, !dbg !41
+  ret i32 0, !dbg !42
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #2
+declare ptr @strcpy(ptr noundef, ptr noundef) #2
 
-declare ptr @strcpy(ptr noundef, ptr noundef) #3
+declare void @svf_assert(i1 noundef) #2
 
-declare void @svf_assert(i1 noundef) #3
-
-declare i64 @strlen(ptr noundef) #3
+declare i64 @strlen(ptr noundef) #2
 
 attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #3 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
-attributes #4 = { nobuiltin "no-builtins" }
+attributes #2 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #3 = { nobuiltin "no-builtins" }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
 !llvm.ident = !{!9}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "09-string-summary.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "c4bbb7985f79dd463b8209db97c3043c")
+!1 = !DIFile(filename: "09-string-summary.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "e0ab0f4e8aec6a66f5e8e40c25c84543")
 !2 = !{i32 7, !"Dwarf Version", i32 5}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
 !4 = !{i32 1, !"wchar_size", i32 4}
@@ -93,8 +95,11 @@ attributes #4 = { nobuiltin "no-builtins" }
 !32 = !DILocation(line: 14, column: 16, scope: !10)
 !33 = !DILocation(line: 14, column: 31, scope: !10)
 !34 = !DILocation(line: 14, column: 5, scope: !10)
-!35 = !DILocation(line: 15, column: 23, scope: !10)
-!36 = !DILocation(line: 15, column: 16, scope: !10)
-!37 = !DILocation(line: 15, column: 31, scope: !10)
-!38 = !DILocation(line: 15, column: 5, scope: !10)
-!39 = !DILocation(line: 16, column: 5, scope: !10)
+!35 = !DILocation(line: 15, column: 16, scope: !10)
+!36 = !DILocation(line: 15, column: 31, scope: !10)
+!37 = !DILocation(line: 15, column: 5, scope: !10)
+!38 = !DILocation(line: 16, column: 23, scope: !10)
+!39 = !DILocation(line: 16, column: 16, scope: !10)
+!40 = !DILocation(line: 16, column: 31, scope: !10)
+!41 = !DILocation(line: 16, column: 5, scope: !10)
+!42 = !DILocation(line: 17, column: 5, scope: !10)

--- a/Assignment-3/Tests/level-1/10-safe-memory.c
+++ b/Assignment-3/Tests/level-1/10-safe-memory.c
@@ -1,0 +1,18 @@
+#include <stdbool.h>
+
+extern void svf_assert(bool);
+extern void SAFE_BUFACCESS(void *, unsigned long);
+extern void SAFE_PTRDEREF(void *);
+
+int main(void) {
+    char buffer[2] = {4, 5};
+    volatile char byte = buffer[1];
+    svf_assert(byte == 5);
+    SAFE_BUFACCESS(&buffer[1], 1);
+
+    int value = 8;
+    volatile int observed = *(volatile int *)&value;
+    svf_assert(observed == 8);
+    SAFE_PTRDEREF(&value);
+    return 0;
+}

--- a/Assignment-3/Tests/level-1/10-safe-memory.ll
+++ b/Assignment-3/Tests/level-1/10-safe-memory.ll
@@ -1,0 +1,101 @@
+; ModuleID = '10-safe-memory.c'
+source_filename = "10-safe-memory.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+@__const.main.buffer = private unnamed_addr constant [2 x i8] c"\04\05", align 1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 !dbg !14 {
+entry:
+  %retval = alloca i32, align 4
+  %buffer = alloca [2 x i8], align 1
+  %byte = alloca i8, align 1
+  %value = alloca i32, align 4
+  %observed = alloca i32, align 4
+  store i32 0, ptr %retval, align 4
+    #dbg_declare(ptr %buffer, !18, !DIExpression(), !23)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %buffer, ptr align 1 @__const.main.buffer, i64 2, i1 false), !dbg !23
+    #dbg_declare(ptr %byte, !24, !DIExpression(), !26)
+  %arrayidx = getelementptr inbounds [2 x i8], ptr %buffer, i64 0, i64 1, !dbg !27
+  %0 = load i8, ptr %arrayidx, align 1, !dbg !27
+  store volatile i8 %0, ptr %byte, align 1, !dbg !26
+  %1 = load volatile i8, ptr %byte, align 1, !dbg !28
+  %conv = zext i8 %1 to i32, !dbg !28
+  %cmp = icmp eq i32 %conv, 5, !dbg !29
+  call void @svf_assert(i1 noundef %cmp) #3, !dbg !30
+  %arrayidx2 = getelementptr inbounds [2 x i8], ptr %buffer, i64 0, i64 1, !dbg !31
+  call void @SAFE_BUFACCESS(ptr noundef %arrayidx2, i64 noundef 1) #3, !dbg !32
+    #dbg_declare(ptr %value, !33, !DIExpression(), !34)
+  store i32 8, ptr %value, align 4, !dbg !34
+    #dbg_declare(ptr %observed, !35, !DIExpression(), !36)
+  %2 = load volatile i32, ptr %value, align 4, !dbg !37
+  store volatile i32 %2, ptr %observed, align 4, !dbg !36
+  %3 = load volatile i32, ptr %observed, align 4, !dbg !38
+  %cmp3 = icmp eq i32 %3, 8, !dbg !39
+  call void @svf_assert(i1 noundef %cmp3) #3, !dbg !40
+  call void @SAFE_PTRDEREF(ptr noundef %value) #3, !dbg !41
+  ret i32 0, !dbg !42
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
+
+declare void @svf_assert(i1 noundef) #2
+
+declare void @SAFE_BUFACCESS(ptr noundef, i64 noundef) #2
+
+declare void @SAFE_PTRDEREF(ptr noundef) #2
+
+attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { "frame-pointer"="non-leaf" "no-builtins" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }
+attributes #3 = { nobuiltin "no-builtins" }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!6, !7, !8, !9, !10, !11, !12}
+!llvm.ident = !{!13}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "10-safe-memory.c", directory: "/workspace/Assignment-3/Tests/level-1", checksumkind: CSK_MD5, checksum: "71708700e208be20b4f9300472b66d04")
+!2 = !{!3}
+!3 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!4 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !5)
+!5 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!6 = !{i32 7, !"Dwarf Version", i32 5}
+!7 = !{i32 2, !"Debug Info Version", i32 3}
+!8 = !{i32 1, !"wchar_size", i32 4}
+!9 = !{i32 8, !"PIC Level", i32 2}
+!10 = !{i32 7, !"PIE Level", i32 2}
+!11 = !{i32 7, !"uwtable", i32 2}
+!12 = !{i32 7, !"frame-pointer", i32 1}
+!13 = !{!"clang version 21.1.0 (https://github.com/bjjwwang/LLVM-compile 56e2582eb90f98cb21f19cd6d72cca341b06d1bf)"}
+!14 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !15, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !17)
+!15 = !DISubroutineType(types: !16)
+!16 = !{!5}
+!17 = !{}
+!18 = !DILocalVariable(name: "buffer", scope: !14, file: !1, line: 8, type: !19)
+!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 16, elements: !21)
+!20 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
+!21 = !{!22}
+!22 = !DISubrange(count: 2)
+!23 = !DILocation(line: 8, column: 10, scope: !14)
+!24 = !DILocalVariable(name: "byte", scope: !14, file: !1, line: 9, type: !25)
+!25 = !DIDerivedType(tag: DW_TAG_volatile_type, baseType: !20)
+!26 = !DILocation(line: 9, column: 19, scope: !14)
+!27 = !DILocation(line: 9, column: 26, scope: !14)
+!28 = !DILocation(line: 10, column: 16, scope: !14)
+!29 = !DILocation(line: 10, column: 21, scope: !14)
+!30 = !DILocation(line: 10, column: 5, scope: !14)
+!31 = !DILocation(line: 11, column: 21, scope: !14)
+!32 = !DILocation(line: 11, column: 5, scope: !14)
+!33 = !DILocalVariable(name: "value", scope: !14, file: !1, line: 13, type: !5)
+!34 = !DILocation(line: 13, column: 9, scope: !14)
+!35 = !DILocalVariable(name: "observed", scope: !14, file: !1, line: 14, type: !4)
+!36 = !DILocation(line: 14, column: 18, scope: !14)
+!37 = !DILocation(line: 14, column: 29, scope: !14)
+!38 = !DILocation(line: 15, column: 16, scope: !14)
+!39 = !DILocation(line: 15, column: 25, scope: !14)
+!40 = !DILocation(line: 15, column: 5, scope: !14)
+!41 = !DILocation(line: 16, column: 5, scope: !14)
+!42 = !DILocation(line: 17, column: 5, scope: !14)

--- a/Assignment-3/Tests/level-2/notes.md
+++ b/Assignment-3/Tests/level-2/notes.md
@@ -18,7 +18,7 @@ Validation:
 
 - ASAN confirms the target at `curl_fnmatch.c:389`.
 - C++ command:
-  `Release-build/bin/ass3 Assignment-3/Tests/level-2/repro.ll`
+  `"$BUILD_DIR/bin/ass3" Assignment-3/Tests/level-2/repro.ll`
 - Python command:
   `python3 Assignment-3/Python/test-ae.py Assignment-3/Tests/level-2/repro.ll`
 - ICFG coverage: 7938 / 7939 = 99.99%

--- a/Assignment-3/Tests/test-reporter-contract.py
+++ b/Assignment-3/Tests/test-reporter-contract.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+"""Regression checks for Assignment 3's typed report contract."""
+
+from pathlib import Path
+import sys
+
+
+PYTHON_DIR = Path(__file__).resolve().parents[1] / "Python"
+sys.path.insert(0, str(PYTHON_DIR))
+
+from AEReporter import AEReporter  # noqa: E402
+
+
+def main() -> None:
+    reporter = AEReporter(None)
+    access = object()
+
+    reporter.reportBufOverflow(access, "first buffer report")
+    reporter.reportBufOverflow(access, "duplicate buffer report")
+    reporter.reportNullDeref(access, "null report at the same node")
+
+    assert reporter.getReportCount() == 2
+    assert reporter.getReportCount("buffer-overflow") == 1
+    assert reporter.getReportCount("nullptr-deref") == 1
+
+    reporter.noteExpectedReport("buffer-overflow")
+    reporter.noteExpectedReport("nullptr-deref")
+    reporter.noteExpectedReport("nullptr-deref")
+
+    assert reporter.getExpectedReportCount("buffer-overflow") == 1
+    assert reporter.getExpectedReportCount("nullptr-deref") == 2
+    assert reporter.getExpectedReportCount("unknown-kind") == 0
+
+
+if __name__ == "__main__":
+    main()

--- a/Assignment-3/Tests/test-reporter-contract.py
+++ b/Assignment-3/Tests/test-reporter-contract.py
@@ -4,10 +4,30 @@
 
 from pathlib import Path
 import sys
+import types
 
 
 PYTHON_DIR = Path(__file__).resolve().parents[1] / "Python"
 sys.path.insert(0, str(PYTHON_DIR))
+
+try:
+    import pysvf  # noqa: F401
+except ModuleNotFoundError:
+    # Reporting/counting is intentionally independent of the SVF domain.
+    # Lightweight stand-ins let CI execute this contract test even when it
+    # builds only the C++ SVF package and has no PySVF wheel installed.
+    fake_pysvf = types.ModuleType("pysvf")
+    for type_name in (
+            "AbstractState", "AbstractValue", "AddrStmt", "AddressValue",
+            "GepStmt", "IntervalValue", "SVFIR", "SVFVar"):
+        setattr(fake_pysvf, type_name, type(type_name, (), {}))
+    fake_pysvf.Options = type("Options", (), {})
+    sys.modules["pysvf"] = fake_pysvf
+
+    fake_ae_state = types.ModuleType("AEState")
+    fake_ae_state.AEState = type("AEState", (), {})
+    fake_ae_state.unwrap_state = lambda state: state
+    sys.modules["AEState"] = fake_ae_state
 
 from AEReporter import AEReporter  # noqa: E402
 
@@ -24,9 +44,13 @@ def main() -> None:
     assert reporter.getReportCount("buffer-overflow") == 1
     assert reporter.getReportCount("nullptr-deref") == 1
 
-    reporter.noteExpectedReport("buffer-overflow")
-    reporter.noteExpectedReport("nullptr-deref")
-    reporter.noteExpectedReport("nullptr-deref")
+    buffer_checkpoint = object()
+    null_checkpoint_1 = object()
+    null_checkpoint_2 = object()
+    reporter.noteExpectedReport("buffer-overflow", buffer_checkpoint)
+    reporter.noteExpectedReport("nullptr-deref", null_checkpoint_1)
+    reporter.noteExpectedReport("nullptr-deref", null_checkpoint_2)
+    reporter.noteExpectedReport("nullptr-deref", null_checkpoint_1)
 
     assert reporter.getExpectedReportCount("buffer-overflow") == 1
     assert reporter.getExpectedReportCount("nullptr-deref") == 2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Static Analysis Course / Software Security Analysis Course
 [Course Content](https://github.com/SVF-tools/Software-Security-Analysis/wiki)
 
+[Assignment 3: authoritative specification](Assignment-3/README.md)
+
 If you fork this repository, please make it as private and do not disclose your solutions. 

--- a/docs/superpowers/plans/2026-07-28-assignment-3-release-hardening.md
+++ b/docs/superpowers/plans/2026-07-28-assignment-3-release-hardening.md
@@ -114,7 +114,8 @@ build is supplied, but documentation/path checks pass.
 - Modify: `Assignment-3/CPP/AEHelper.cpp`
 
 **Interfaces:**
-- Produces: `noteExpectedReport(kind)`, `getExpectedReportCount(kind)`, and `getReportCount(kind)` on `AEReporter`.
+- Produces: `noteExpectedReport(kind, checkpoint)`,
+  `getExpectedReportCount(kind)`, and `getReportCount(kind)` on `AEReporter`.
 - Consumes: typed reports already stored in `AssignmentBugReport`.
 
 - [ ] **Step 1: Add an expectation-count regression test to the validation path**
@@ -158,7 +159,9 @@ Expected: target builds without warnings or errors.
 - Modify: `Assignment-3/Python/Assignment_3.py`
 
 **Interfaces:**
-- Produces: `reportBug(kind, node, message)`, `reportNullDeref(node, message)`, `getReportCount(kind)`, `noteExpectedReport(kind)`, and `getExpectedReportCount(kind)`.
+- Produces: `reportBug(kind, node, message)`, `reportNullDeref(node, message)`,
+  `getReportCount(kind)`, `noteExpectedReport(kind, checkpoint)`, and
+  `getExpectedReportCount(kind)`.
 - Retains: `reportBufOverflow(node, message)` compatibility.
 
 - [ ] **Step 1: Write the failing reporter contract test**

--- a/docs/superpowers/plans/2026-07-28-assignment-3-release-hardening.md
+++ b/docs/superpowers/plans/2026-07-28-assignment-3-release-hardening.md
@@ -1,0 +1,380 @@
+# Assignment 3 Release Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a consistent, versioned, and testable Assignment 3 specification with meaningful public cases and automated drift checks.
+
+**Architecture:** Keep the detailed student contract in `Assignment-3/README.md`, treat checkpoint stubs as expectation markers rather than detectors, and expose typed report counts in both harnesses. Register focused LLVM IR cases through the existing CMake structure and validate the documented commands in the existing build workflow.
+
+**Tech Stack:** Markdown, Bash, CMake/CTest, C++17, Python 3/PySVF, LLVM 21 IR, GitHub Actions.
+
+## Global Constraints
+
+- Do not add solution implementations to `Assignment_3.cpp`, `Assignment_3.h`, or `Assignment_3.py` beyond pre-implemented reporter forwarding.
+- C++ students continue to submit only `Assignment_3.cpp` and `Assignment_3.h`.
+- Python students continue to submit only `Assignment_3.py`.
+- Public checker expectations are compared separately for `buffer-overflow` and `nullptr-deref`.
+- The provided Docker checkout and the documented `build/` checkout must both have working commands.
+- The GitHub Wiki is committed separately and is not pushed without explicit approval.
+
+---
+
+### Task 1: Add the release contract checker
+
+**Files:**
+- Create: `scripts/check-assignment-3-release.sh`
+- Modify: `.github/workflows/build.yml`
+
+**Interfaces:**
+- Consumes: a configured repository path as argument 1, defaulting to the repository root.
+- Produces: exit status 0 only when documented Assignment 3 test selectors and paths are valid.
+
+- [ ] **Step 1: Write the failing release checker**
+
+Create a shell checker that runs `ctest -N` with
+`^ass3-level-1-cpp/` and `^ass3-level-1-py/`, verifies a non-zero test count,
+checks all public IR paths listed in the release manifest, and rejects
+`Release-build` plus deleted flat test paths in Assignment 3 repository
+documentation.
+
+- [ ] **Step 2: Verify the checker fails on the current documentation**
+
+Run:
+
+```bash
+bash scripts/check-assignment-3-release.sh .
+```
+
+Expected: non-zero exit because the current public-case README hard-codes
+`Release-build`.
+
+- [ ] **Step 3: Wire the checker into CI**
+
+Add a build-workflow step after `make`:
+
+```yaml
+- name: validate-assignment-3-release
+  run: |
+    bash scripts/check-assignment-3-release.sh .
+```
+
+- [ ] **Step 4: Keep the checker red until Task 2 corrects the docs**
+
+Do not weaken the validation to accept the current broken command.
+
+### Task 2: Create the authoritative specification and portable commands
+
+**Files:**
+- Create: `Assignment-3/README.md`
+- Modify: `Assignment-3/Tests/README.md`
+- Modify: `Assignment-3/Tests/GRADING.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: current CMake target names, public-case locations, harness APIs, and grading structure.
+- Produces: one authoritative Assignment 3 contract linked from the repository root.
+
+- [ ] **Step 1: Write `Assignment-3/README.md`**
+
+Include deliverables, the five entry points, all six tasks, the checker and
+external-call semantic tables, fixpoint pseudocode, portable `BUILD_DIR`
+commands, public timeouts, marking language, submission commands, and a
+student-authored test recipe using LLVM 21.
+
+- [ ] **Step 2: Correct the public-case operator guide**
+
+Replace `Release-build` with `BUILD_DIR`, add exact C++ and Python anchored
+CTest selectors, and document direct Level-1 and Level-2 commands.
+
+- [ ] **Step 3: Reconcile grading language**
+
+State the 30/40/30 split, define target detection and report precision, state
+the public CTest timeouts, and explicitly distinguish public development cases
+from hidden marking cases.
+
+- [ ] **Step 4: Link the authoritative specification**
+
+Add an Assignment 3 link to the repository root README.
+
+- [ ] **Step 5: Run the release checker**
+
+Run:
+
+```bash
+bash scripts/check-assignment-3-release.sh .
+```
+
+Expected: CTest selector checks may remain unavailable until a configured
+build is supplied, but documentation/path checks pass.
+
+### Task 3: Separate checkpoint expectations from C++ reports
+
+**Files:**
+- Modify: `Assignment-3/CPP/AEReporter.h`
+- Modify: `Assignment-3/CPP/AEHelper.cpp`
+
+**Interfaces:**
+- Produces: `noteExpectedReport(kind)`, `getExpectedReportCount(kind)`, and `getReportCount(kind)` on `AEReporter`.
+- Consumes: typed reports already stored in `AssignmentBugReport`.
+
+- [ ] **Step 1: Add an expectation-count regression test to the validation path**
+
+Use the Level-1 buffer/null cases as the integration regression: with
+checkpoint-side reporting removed, a no-op checker must no longer satisfy the
+unsafe expected count.
+
+- [ ] **Step 2: Record expected kinds at checkpoints**
+
+For `UNSAFE_BUFACCESS`, record one expected `buffer-overflow`; for
+`UNSAFE_PTRDEREF`, record one expected `nullptr-deref`. SAFE checkpoints record
+no expected report. All checkpoints still record reachability.
+
+- [ ] **Step 3: Remove checkpoint-side detection and reporting**
+
+Delete the harness-only safety predicates and remove calls to
+`reportBufOverflow` and `reportNullDeref` from `handleCheckpointStubs`.
+
+- [ ] **Step 4: Validate exact per-kind counts**
+
+In `ensureAllAssertsValidated`, compare expected and actual counts separately
+and emit a diagnostic naming the mismatched kind before asserting.
+
+- [ ] **Step 5: Build the C++ targets**
+
+Run:
+
+```bash
+cmake --build "$BUILD_DIR" --target ass3 -j8
+```
+
+Expected: target builds without warnings or errors.
+
+### Task 4: Add typed Python reporting and checkpoint expectations
+
+**Files:**
+- Create: `Assignment-3/Tests/test-reporter-contract.py`
+- Modify: `Assignment-3/Python/AEReporter.py`
+- Modify: `Assignment-3/Python/AEHelper.py`
+- Modify: `Assignment-3/Python/Assignment_3.py`
+
+**Interfaces:**
+- Produces: `reportBug(kind, node, message)`, `reportNullDeref(node, message)`, `getReportCount(kind)`, `noteExpectedReport(kind)`, and `getExpectedReportCount(kind)`.
+- Retains: `reportBufOverflow(node, message)` compatibility.
+
+- [ ] **Step 1: Write the failing reporter contract test**
+
+The test creates an `AEReporter`, records one report of each kind plus one
+duplicate, and asserts independent counts and expected-count bookkeeping.
+
+- [ ] **Step 2: Verify the reporter test fails**
+
+Run in the course Python environment:
+
+```bash
+python3 Assignment-3/Tests/test-reporter-contract.py
+```
+
+Expected: failure because null-specific and count APIs do not exist.
+
+- [ ] **Step 3: Implement typed Python reports**
+
+Store reports by `(kind, node)`, retain human-readable printing, and implement
+the count and expectation methods.
+
+- [ ] **Step 4: Change Python checkpoints to expectation markers**
+
+Remove harness-side safety decisions and compare exact per-kind counts in
+`ensureAllAssertsValidated`.
+
+- [ ] **Step 5: Correct the null-report forwarder**
+
+Route `Assignment3.reportNullDeref` through
+`AEReporter.reportNullDeref`.
+
+- [ ] **Step 6: Verify the reporter test passes**
+
+Run:
+
+```bash
+python3 Assignment-3/Tests/test-reporter-contract.py
+```
+
+Expected: one test process exits 0.
+
+### Task 5: Expand focused public cases
+
+**Files:**
+- Modify: `Assignment-3/Tests/level-1/03-buffer-overflow.c`
+- Modify: `Assignment-3/Tests/level-1/03-buffer-overflow.ll`
+- Modify: `Assignment-3/Tests/level-1/04-nullptr-deref.c`
+- Modify: `Assignment-3/Tests/level-1/04-nullptr-deref.ll`
+- Create: `Assignment-3/Tests/level-1/05-loop-fixpoint.c`
+- Create: `Assignment-3/Tests/level-1/05-loop-fixpoint.ll`
+- Create: `Assignment-3/Tests/level-1/06-recursion-fixpoint.c`
+- Create: `Assignment-3/Tests/level-1/06-recursion-fixpoint.ll`
+- Create: `Assignment-3/Tests/level-1/07-interprocedural-call-return.c`
+- Create: `Assignment-3/Tests/level-1/07-interprocedural-call-return.ll`
+- Create: `Assignment-3/Tests/level-1/08-memory-summary.c`
+- Create: `Assignment-3/Tests/level-1/08-memory-summary.ll`
+- Create: `Assignment-3/Tests/level-1/09-string-summary.c`
+- Create: `Assignment-3/Tests/level-1/09-string-summary.ll`
+- Create: `Assignment-3/Tests/level-1/10-safe-memory.c`
+- Create: `Assignment-3/Tests/level-1/10-safe-memory.ll`
+
+**Interfaces:**
+- Consumes: `svf_assert`, `SAFE_*`, and `UNSAFE_*` harness stubs.
+- Produces: one self-validating IR case for each published primary contract.
+
+- [ ] **Step 1: Make unsafe checker sources contain real accesses**
+
+Add a real out-of-bounds volatile load to case 03 and a real volatile null
+load to case 04 before their expectation markers.
+
+- [ ] **Step 2: Add loop, recursion, and call/return sources**
+
+Use exact small integer bounds so assertions are decidable after a correct
+fixpoint.
+
+- [ ] **Step 3: Add memory and string summary sources**
+
+Use non-builtin calls and `svf_assert` checks on copied values and returned
+lengths.
+
+- [ ] **Step 4: Add a safe checker source**
+
+Perform one in-bounds buffer read and one non-null dereference, followed by
+their SAFE markers. Exact report-count validation must remain zero.
+
+- [ ] **Step 5: Compile LLVM 21 IR**
+
+For every source:
+
+```bash
+clang -g -O0 -fno-discard-value-names -fno-builtin \
+  -S -emit-llvm case.c -o case.ll
+```
+
+- [ ] **Step 6: Run the reference implementation**
+
+Run C++ and Python against each Level-1 IR case. Expected: every case exits 0;
+unsafe cases produce exactly one report of the expected kind and safe cases
+produce none.
+
+### Task 6: Validate the complete repository change
+
+**Files:**
+- Review all modified repository files.
+
+**Interfaces:**
+- Consumes: all preceding tasks.
+- Produces: build, reporter, release-contract, formatting, and diff evidence.
+
+- [ ] **Step 1: Run the reporter contract test**
+
+```bash
+python3 Assignment-3/Tests/test-reporter-contract.py
+```
+
+- [ ] **Step 2: Build the repository**
+
+```bash
+cmake --build "$BUILD_DIR" -j8
+```
+
+- [ ] **Step 3: Validate documented selectors**
+
+```bash
+bash scripts/check-assignment-3-release.sh "$BUILD_DIR"
+```
+
+- [ ] **Step 4: Check patch quality**
+
+```bash
+git diff --check
+git status --short
+```
+
+- [ ] **Step 5: Inspect the final diff**
+
+Confirm no student solution implementation appears and every generated IR
+file corresponds to its source case.
+
+### Task 7: Prepare and validate the wiki commit
+
+**Files:**
+- Modify in the wiki repository: `Assignment-3.md`
+- Modify in the wiki repository: `Assignment-3-CPP.md`
+- Modify in the wiki repository: `Assignment-3-Python.md`
+- Modify in the wiki repository: `Installation-of-Docker-and-Coding-Inside-Docker-Image.md`
+- Modify in the wiki repository: `Building-Software-Security-Analysis-Repo-from-scratch.md`
+- Modify in the wiki repository: `Building-Software-Security-Analysis-Repo-from-scratch-Python.md`
+- Modify in the wiki repository: `Configure-Python-IDE-Environment.md`
+
+**Interfaces:**
+- Consumes: the authoritative repository specification and current public case paths.
+- Produces: a local wiki commit ready for an explicitly approved direct push.
+
+- [ ] **Step 1: Reduce duplicated assignment behavior**
+
+Make `Assignment-3.md` link to `Assignment-3/README.md` as authoritative while
+retaining the course summary and submission links.
+
+- [ ] **Step 2: Correct language pages**
+
+Use anchored CTest selectors, portable build-directory guidance, correct
+anchors, `std::endl`, `toString()`, and accurate Python `AEState` wrapper
+terminology.
+
+- [ ] **Step 3: Correct stale setup paths**
+
+Replace the three deleted flat test paths in every setup page with current
+Level-1 paths.
+
+- [ ] **Step 4: Validate wiki references**
+
+Run:
+
+```bash
+rg 'Tests/(stmt|buf_overflow|null_deref)\.ll|Release-build|ass3-(cpp|py)' .
+```
+
+Expected: no obsolete Assignment 3 instructions.
+
+- [ ] **Step 5: Commit without pushing**
+
+Create a local wiki commit and report its hash. Do not push to `master`
+without explicit user approval.
+
+### Task 8: Create the pull request and change table
+
+**Files:**
+- No additional repository files.
+
+**Interfaces:**
+- Consumes: verified repository branch and committed wiki branch.
+- Produces: fork branch, upstream pull request, and one-to-one change table.
+
+- [ ] **Step 1: Commit repository changes**
+
+Use focused commits for release checking, harness behavior, public cases, and
+documentation.
+
+- [ ] **Step 2: Push the feature branch to the authenticated fork**
+
+```bash
+git push -u fork docs/ass3-release-hardening
+```
+
+- [ ] **Step 3: Open the upstream pull request**
+
+Target `SVF-tools/Software-Security-Analysis:main`. Include verification
+evidence, the wiki limitation, and the change table.
+
+- [ ] **Step 4: Produce the one-to-one table**
+
+For every changed path, list:
+
+| Changed file location | Before change | After change |
+|---|---|---|
+
+Include the table in both the PR description and the user handoff.

--- a/docs/superpowers/specs/2026-07-28-assignment-3-release-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-28-assignment-3-release-hardening-design.md
@@ -95,7 +95,7 @@ reference grader:
 - object and access sizes are bytes;
 - a non-zero access beginning one-past the object is out of bounds;
 - merely constructing a one-past pointer is not a dereference;
-- reports are deduplicated by bug kind and source location;
+- reports are deduplicated by bug kind and ICFG node;
 - external summaries preserve C return values and model the documented
   read/write range;
 - WTO iteration uses precise iterations through the configured widening delay,

--- a/docs/superpowers/specs/2026-07-28-assignment-3-release-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-28-assignment-3-release-hardening-design.md
@@ -1,0 +1,137 @@
+# Assignment 3 Release Hardening Design
+
+## Objective
+
+Make Assignment 3 self-consistent and verifiable for students by versioning
+the authoritative specification with the template, publishing commands that
+work in both supported build layouts, separating checkpoint expectations from
+student-generated bug reports, adding focused public cases, and rejecting
+future documentation drift in CI.
+
+## Source of truth
+
+`Assignment-3/README.md` becomes the authoritative student specification.
+It owns:
+
+- the five driver entry points and six assessed tasks;
+- the exact abstract-domain and checker policy;
+- external-call summary contracts;
+- public build and run commands;
+- assessment and submission rules.
+
+`Assignment-3/Tests/README.md` remains the public-case operator guide and
+`Assignment-3/Tests/GRADING.md` remains the marking overview. The GitHub Wiki
+keeps course navigation, setup guidance, and short language-specific pages,
+but links to the versioned specification for assignment behavior.
+
+## Build and test commands
+
+All commands are written in terms of `BUILD_DIR`:
+
+```bash
+BUILD_DIR=build  # from-source guide
+# BUILD_DIR=.    # provided Docker checkout
+```
+
+Language-specific public tests use anchored CTest names:
+
+```bash
+ctest --test-dir "$BUILD_DIR" -R '^ass3-level-1-cpp/' --output-on-failure
+ctest --test-dir "$BUILD_DIR" -R '^ass3-level-1-py/' --output-on-failure
+```
+
+The documentation calls these “registered public Level-1 tests”; it does not
+imply that Level 2 or Level 3 is registered with CTest.
+
+## Checkpoint and reporting contract
+
+`SAFE_*` and `UNSAFE_*` calls are ground-truth markers, not detectors. Reaching
+a checkpoint records:
+
+- the call site;
+- the expected bug kind (`buffer-overflow` or `nullptr-deref`);
+- whether the case expects an unsafe report.
+
+Checkpoint dispatch does not call `reportBufOverflow` or `reportNullDeref`.
+After analysis, validation checks:
+
+1. every assertion/checkpoint call site was reached;
+2. actual report counts match unsafe checkpoint counts separately by kind.
+
+Public checker cases isolate one property per input, so exact per-kind counts
+also reject false positives. Both language harnesses expose typed report
+counts. Python retains its existing `reportBufOverflow` API while adding
+`reportNullDeref` and a common typed reporting implementation.
+
+## Public case coverage
+
+The focused Level-1 corpus covers:
+
+| Case | Primary contract |
+|---|---|
+| `01-stmt-basic` | scalar statement transfer |
+| `02-branch-feasible` | conditional feasibility |
+| `03-buffer-overflow` | direct out-of-bounds memory access |
+| `04-nullptr-deref` | direct null dereference |
+| `05-loop-fixpoint` | loop convergence and narrowing precision |
+| `06-recursion-fixpoint` | recursive SCC convergence |
+| `07-interprocedural-call-return` | actual/formal and return propagation |
+| `08-memory-summary` | `memcpy`/`memset` value effects |
+| `09-string-summary` | `strcpy`/`strlen` value effects |
+| `10-safe-memory` | safe buffer and pointer accesses produce no report |
+
+Each `.c` file is compiled to matching LLVM 21 textual IR with debug
+locations, `-O0`, and `-fno-discard-value-names`. The committed `.ll` file is
+the CTest input; the `.c` file documents intent.
+
+## Required semantic policy
+
+The specification publishes the behavior expected by the supplied harness and
+reference grader:
+
+- address sets use may semantics: one possible null, freed, or out-of-bounds
+  address is reportable;
+- unknown/black-hole objects do not manufacture a precise bug report;
+- object and access sizes are bytes;
+- a non-zero access beginning one-past the object is out of bounds;
+- merely constructing a one-past pointer is not a dereference;
+- reports are deduplicated by bug kind and source location;
+- external summaries preserve C return values and model the documented
+  read/write range;
+- WTO iteration uses precise iterations through the configured widening delay,
+  widening to stability, then narrowing to recover precision.
+
+## Assessment language
+
+All student-facing pages use the 30/40/30 level split. Public examples are
+development aids and do not map one-to-one to marks. Public CTest timeouts are
+120 seconds for C++ and 180 seconds for Python. Hidden-case counts, weights,
+and environment-specific timeouts remain unpublished, but the meaning of
+target detection, false positives, completion, and coverage is stated.
+
+## Drift prevention
+
+`scripts/check-assignment-3-release.sh` validates the release from a configured
+checkout:
+
+- both documented language-specific CTest regexes select tests;
+- every documented public `.ll` input exists;
+- obsolete flat Assignment-3 test paths are absent;
+- Assignment-3 repository documentation does not hard-code
+  `Release-build`.
+
+The existing build workflow runs this checker after configuration. This
+validates commands and filesystem behavior without executing the intentionally
+incomplete student analyzer.
+
+## Wiki delivery
+
+The wiki is a separate Git repository and GitHub does not support wiki pull
+requests. Wiki changes are prepared as a local commit that:
+
+- points Assignment 3 to the repository-owned specification;
+- corrects test commands, anchors, snippets, wrapper terminology, and paths;
+- corrects Assignment 3 paths in Docker, from-source, and Python IDE pages.
+
+Publishing that commit requires an explicit direct push to the wiki’s
+`master` branch.

--- a/scripts/check-assignment-3-release.sh
+++ b/scripts/check-assignment-3-release.sh
@@ -32,13 +32,20 @@ check_ctest_selector()
 if [[ -f "$build_dir/CTestTestfile.cmake" ]]; then
     check_ctest_selector '^ass3-level-1-cpp/' 'Assignment 3 C++'
     check_ctest_selector '^ass3-level-1-py/' 'Assignment 3 Python'
+    check_ctest_selector '^ass3-harness-py/reporter-contract$' \
+        'Assignment 3 Python reporter-contract'
 else
     printf 'SKIP: no configured CTest tree at %s\n' "$build_dir"
 fi
 
 documented_ir=$(
-    rg -o --no-filename 'Assignment-3/Tests/[A-Za-z0-9._/-]+\.ll' \
-        "$repo_root/Assignment-3" "$repo_root/README.md" |
+    {
+        grep -ERoh --include='*.md' \
+            'Assignment-3/Tests/[A-Za-z0-9._/-]+\.ll' \
+            "$repo_root/Assignment-3" || true
+        grep -Eoh 'Assignment-3/Tests/[A-Za-z0-9._/-]+\.ll' \
+            "$repo_root/README.md" || true
+    } |
         sort -u || true
 )
 
@@ -55,12 +62,26 @@ while IFS= read -r relative_path; do
     fi
 done <<< "$documented_ir"
 
-if rg -n 'Assignment-3/Tests/(stmt|buf_overflow|null_deref)\.ll' \
-    "$repo_root" -g '*.md'; then
+level1_sources_found=0
+for source_path in "$repo_root"/Assignment-3/Tests/level-1/*.c; do
+    [[ -e "$source_path" ]] || continue
+    level1_sources_found=1
+    ir_path=${source_path%.c}.ll
+    if [[ ! -f "$ir_path" ]]; then
+        fail "public source has no generated LLVM IR pair: ${source_path#"$repo_root/"}"
+    fi
+done
+if [[ "$level1_sources_found" -eq 0 ]]; then
+    fail 'no public Assignment 3 Level-1 sources were found'
+fi
+
+if grep -ERn --include='*.md' \
+    'Assignment-3/Tests/(stmt|buf_overflow|null_deref)\.ll' \
+    "$repo_root/Assignment-3" "$repo_root/README.md"; then
     fail 'obsolete flat Assignment 3 test paths remain in repository documentation'
 fi
 
-if rg -n 'Release-build' "$repo_root/Assignment-3" -g '*.md'; then
+if grep -ERn --include='*.md' 'Release-build' "$repo_root/Assignment-3"; then
     fail 'Assignment 3 documentation hard-codes the unsupported Release-build layout'
 fi
 

--- a/scripts/check-assignment-3-release.sh
+++ b/scripts/check-assignment-3-release.sh
@@ -40,9 +40,9 @@ fi
 
 documented_ir=$(
     {
-        grep -ERoh --include='*.md' \
-            'Assignment-3/Tests/[A-Za-z0-9._/-]+\.ll' \
-            "$repo_root/Assignment-3" || true
+        find "$repo_root/Assignment-3" -type f -name '*.md' \
+            -exec grep -Eoh \
+            'Assignment-3/Tests/[A-Za-z0-9._/-]+\.ll' {} + || true
         grep -Eoh 'Assignment-3/Tests/[A-Za-z0-9._/-]+\.ll' \
             "$repo_root/README.md" || true
     } |
@@ -62,26 +62,45 @@ while IFS= read -r relative_path; do
     fi
 done <<< "$documented_ir"
 
-level1_sources_found=0
-for source_path in "$repo_root"/Assignment-3/Tests/level-1/*.c; do
-    [[ -e "$source_path" ]] || continue
-    level1_sources_found=1
-    ir_path=${source_path%.c}.ll
-    if [[ ! -f "$ir_path" ]]; then
-        fail "public source has no generated LLVM IR pair: ${source_path#"$repo_root/"}"
-    fi
+public_case_ids=(
+    01-stmt-basic
+    02-branch-feasible
+    03-buffer-overflow
+    04-nullptr-deref
+    05-loop-fixpoint
+    06-recursion-fixpoint
+    07-interprocedural-call-return
+    08-memory-summary
+    09-string-summary
+    10-safe-memory
+)
+for case_id in "${public_case_ids[@]}"; do
+    for extension in c ll; do
+        case_path="Assignment-3/Tests/level-1/$case_id.$extension"
+        if [[ ! -f "$repo_root/$case_path" ]]; then
+            fail "public case inventory is missing: $case_path"
+        fi
+    done
 done
-if [[ "$level1_sources_found" -eq 0 ]]; then
-    fail 'no public Assignment 3 Level-1 sources were found'
-fi
 
-if grep -ERn --include='*.md' \
-    'Assignment-3/Tests/(stmt|buf_overflow|null_deref)\.ll' \
-    "$repo_root/Assignment-3" "$repo_root/README.md"; then
+obsolete_paths=$(
+    find "$repo_root/Assignment-3" -type f -name '*.md' \
+        -exec grep -EHn \
+        'Assignment-3/Tests/(stmt|buf_overflow|null_deref)\.ll' {} + || true
+    grep -En 'Assignment-3/Tests/(stmt|buf_overflow|null_deref)\.ll' \
+        "$repo_root/README.md" || true
+)
+if [[ -n "$obsolete_paths" ]]; then
+    printf '%s\n' "$obsolete_paths"
     fail 'obsolete flat Assignment 3 test paths remain in repository documentation'
 fi
 
-if grep -ERn --include='*.md' 'Release-build' "$repo_root/Assignment-3"; then
+release_build_mentions=$(
+    find "$repo_root/Assignment-3" -type f -name '*.md' \
+        -exec grep -EHn 'Release-build' {} + || true
+)
+if [[ -n "$release_build_mentions" ]]; then
+    printf '%s\n' "$release_build_mentions"
     fail 'Assignment 3 documentation hard-codes the unsupported Release-build layout'
 fi
 

--- a/scripts/check-assignment-3-release.sh
+++ b/scripts/check-assignment-3-release.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/.." && pwd)
+build_dir=${1:-$repo_root}
+failures=0
+
+fail()
+{
+    printf 'ERROR: %s\n' "$*" >&2
+    failures=$((failures + 1))
+}
+
+check_ctest_selector()
+{
+    selector=$1
+    label=$2
+    listing=$(ctest --test-dir "$build_dir" -N -R "$selector" 2>&1) || {
+        fail "CTest could not list $label tests from $build_dir"
+        return
+    }
+    count=$(printf '%s\n' "$listing" | sed -n 's/^[[:space:]]*Total Tests: \([0-9][0-9]*\)$/\1/p' | tail -1)
+    if [[ -z "$count" || "$count" -eq 0 ]]; then
+        fail "documented selector $selector matches no $label tests"
+    else
+        printf 'OK: %s selects %s test(s)\n' "$selector" "$count"
+    fi
+}
+
+if [[ -f "$build_dir/CTestTestfile.cmake" ]]; then
+    check_ctest_selector '^ass3-level-1-cpp/' 'Assignment 3 C++'
+    check_ctest_selector '^ass3-level-1-py/' 'Assignment 3 Python'
+else
+    printf 'SKIP: no configured CTest tree at %s\n' "$build_dir"
+fi
+
+documented_ir=$(
+    rg -o --no-filename 'Assignment-3/Tests/[A-Za-z0-9._/-]+\.ll' \
+        "$repo_root/Assignment-3" "$repo_root/README.md" |
+        sort -u || true
+)
+
+if [[ -z "$documented_ir" ]]; then
+    fail 'no public Assignment 3 LLVM IR paths are documented'
+fi
+
+while IFS= read -r relative_path; do
+    [[ -z "$relative_path" ]] && continue
+    if [[ ! -f "$repo_root/$relative_path" ]]; then
+        fail "documented input does not exist: $relative_path"
+    else
+        printf 'OK: documented input exists: %s\n' "$relative_path"
+    fi
+done <<< "$documented_ir"
+
+if rg -n 'Assignment-3/Tests/(stmt|buf_overflow|null_deref)\.ll' \
+    "$repo_root" -g '*.md'; then
+    fail 'obsolete flat Assignment 3 test paths remain in repository documentation'
+fi
+
+if rg -n 'Release-build' "$repo_root/Assignment-3" -g '*.md'; then
+    fail 'Assignment 3 documentation hard-codes the unsupported Release-build layout'
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+    printf 'Assignment 3 release validation failed with %s error(s).\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'Assignment 3 release validation passed.\n'


### PR DESCRIPTION
## Summary

Hardens Assignment 3 for student release by making the repository specification
authoritative, removing contradictory/stale commands, separating ground-truth
checkpoints from student detectors, and expanding focused public coverage.

Key outcomes:

- versioned semantic, build, test, grading, and submission contract;
- anchored CTest commands that select 10 C++ and 10 Python public cases;
- checkpoint stubs record expectations but never produce bug reports;
- exact, callsite-deduplicated report counts for checkpointed bug kinds;
- typed and consistent C++/Python report accounting;
- focused loop, recursion, call/return, memory, string, and precision cases;
- CI validation for documentation drift, public inventory, and the Python
  reporter contract.

## Marking alignment note

The strengthened public cases make two previously implicit requirements
observable: ordinary load/store access width participates in bounds checking,
and `strcpy` copies the terminating null byte. Any private marking/reference
implementation should implement those published semantics before release.

## Verification

- Full CMake repository build in
  `svftools/software-security-analysis:latest`: passed.
- Fork GitHub Actions build passed on Ubuntu and macOS:
  https://github.com/JoelYYoung/Software-Security-Analysis/actions/runs/30342049035
- Release validation: 10 C++ cases, 10 Python cases, and 1 reporter-contract
  test discovered; documented paths and the explicit 01–10 inventory passed.
- Contract-conforming reference run: 21/21 Assignment 3 tests passed.
- All ten Level-1 `.ll` files passed LLVM 21 `llvm-as`.
- Independent blocker-only review: no remaining Critical or Important findings.

The public Level-2 fixture was not added to CTest because it is intentionally
memory-heavy. A local direct attempt was killed by the available Docker memory
limit, consistent with the existing operator note.

## One-to-one changed-file table

| Changed file location | Before | After |
| --- | --- | --- |
| `.github/workflows/build.yml` | Built the repository only. | Runs the Assignment 3 release validator and executable reporter regression after building. |
| `Assignment-3/CPP/AEHelper.cpp` | Checkpoints independently detected and reported bugs; validation required only a combined lower bound. | Checkpoints only record callsite expectations; validation checks exact counts per checkpointed bug kind and permits uncheckpointed real-program reports. |
| `Assignment-3/CPP/AEReporter.h` | Stored reports with location-based dedup and no expected-kind bookkeeping. | Deduplicates by kind plus ICFG node and tracks unique expected checkpoint callsites per kind. |
| `Assignment-3/Python/AEHelper.py` | Python checkpoints ran harness-owned safety predicates and used a combined report lower bound. | Checkpoints only record expectations and exact per-kind validation mirrors C++. |
| `Assignment-3/Python/AEReporter.py` | All reports were an untyped node-to-message map. | Provides typed buffer/null reports, kind counts, callsite expectations, and kind-plus-node deduplication. |
| `Assignment-3/Python/Assignment_3.py` | `reportNullDeref` incorrectly forwarded to `reportBufOverflow`. | Null reports forward to `AEReporter.reportNullDeref`. |
| `Assignment-3/Python/CMakeLists.txt` | Registered only program-analysis cases. | Also registers the isolated reporter-contract regression. |
| `Assignment-3/README.md` | Absent; detailed requirements existed only in mutable wiki prose. | Authoritative versioned contract covering deliverables, six tasks, transfer/external/checker semantics, fixpoints, commands, timeouts, grading, testing, and submission. |
| `Assignment-3/Tests/GRADING.md` | Grading terms and checkpoint success criteria were ambiguous. | Defines 30/40/30 allocation, checkpoint-scoped exact counts, target/precision/completion/coverage terms, public timeouts, and hidden-suite boundaries. |
| `Assignment-3/Tests/README.md` | Hard-coded `Release-build`, omitted language-specific selectors, and listed four cases. | Uses portable `BUILD_DIR`, exact anchored selectors, direct commands, timeouts, and the ten-case inventory. |
| `Assignment-3/Tests/level-1/03-buffer-overflow.c` | Contained only a one-past pointer passed to a checkpoint. | Performs one real four-byte load through a one-byte object, then records one unsafe expectation. |
| `Assignment-3/Tests/level-1/03-buffer-overflow.ll` | LLVM IR contained only the checkpoint-side one-past GEP. | LLVM 21 IR contains the real wide load and regenerated checkpoint call. |
| `Assignment-3/Tests/level-1/04-nullptr-deref.c` | Passed null directly to a checkpoint without dereferencing it. | Performs a real volatile null dereference before the expectation marker. |
| `Assignment-3/Tests/level-1/04-nullptr-deref.ll` | LLVM IR contained only a null checkpoint argument. | LLVM 21 IR contains the real null load and regenerated marker. |
| `Assignment-3/Tests/level-1/05-loop-fixpoint.c` | Absent. | Adds a nondeterministic unbounded loop whose invariant requires a terminating widening fixpoint. |
| `Assignment-3/Tests/level-1/05-loop-fixpoint.ll` | Absent. | Adds generated LLVM 21 IR for the loop fixpoint case. |
| `Assignment-3/Tests/level-1/06-recursion-fixpoint.c` | Absent. | Adds a recursive-SCC reachability and refinement case. |
| `Assignment-3/Tests/level-1/06-recursion-fixpoint.ll` | Absent. | Adds generated LLVM 21 IR for the recursion case. |
| `Assignment-3/Tests/level-1/07-interprocedural-call-return.c` | Absent. | Adds a focused actual/formal and return-value propagation case. |
| `Assignment-3/Tests/level-1/07-interprocedural-call-return.ll` | Absent. | Adds generated LLVM 21 IR for call/return propagation. |
| `Assignment-3/Tests/level-1/08-memory-summary.c` | Absent. | Adds a focused `memcpy` value-summary case. |
| `Assignment-3/Tests/level-1/08-memory-summary.ll` | Absent. | Adds generated LLVM 21 IR for the memory summary. |
| `Assignment-3/Tests/level-1/09-string-summary.c` | Absent. | Adds `strcpy`/`strlen` value checks and verifies copied null-terminator semantics. |
| `Assignment-3/Tests/level-1/09-string-summary.ll` | Absent. | Adds generated LLVM 21 IR for the string summary. |
| `Assignment-3/Tests/level-1/10-safe-memory.c` | Absent. | Adds real safe load/dereference operations and safe checkpoints to catch false positives. |
| `Assignment-3/Tests/level-1/10-safe-memory.ll` | Absent. | Adds generated LLVM 21 IR for safe-report precision. |
| `Assignment-3/Tests/level-2/notes.md` | Hard-coded the unsupported `Release-build` layout. | Uses the documented `BUILD_DIR` convention. |
| `Assignment-3/Tests/test-reporter-contract.py` | Absent. | Adds an executable, no-PySVF-required regression for typed reports, deduplication, and expected callsite counts. |
| `README.md` | Linked only to the course wiki. | Also links directly to the authoritative Assignment 3 specification. |
| `docs/superpowers/plans/2026-07-28-assignment-3-release-hardening.md` | Absent. | Records the implementation and verification plan. |
| `docs/superpowers/specs/2026-07-28-assignment-3-release-hardening-design.md` | Absent. | Records the approved release-hardening design and decisions. |
| `scripts/check-assignment-3-release.sh` | Absent. | Validates non-empty anchored selectors, reporter-test discovery, explicit 01–10 source/IR inventory, documented IR paths, and forbidden stale build/path references. |

## Wiki

The GitHub wiki is a separate Git repository and GitHub does not provide pull
requests for it. Matching wiki edits are committed locally on
`ass3-release-hardening` (`5b61901`, `6fe71cb`) but were not pushed, so this PR
does not mutate the live wiki.
